### PR TITLE
Handle close event completelly in closeWindow() instead of using the def...

### DIFF
--- a/Baselet/src/com/baselet/gui/standalone/StandaloneGUI.java
+++ b/Baselet/src/com/baselet/gui/standalone/StandaloneGUI.java
@@ -70,8 +70,7 @@ public class StandaloneGUI extends BaseGUI {
 		guiBuilder.getMailPanel().closePanel(); // We must close the mailpanel to save the input date
 		if (askSaveForAllDirtyDiagrams()) {
 			main.closeProgram();
-			mainFrame.dispose();
-			// System.exit(0);
+			System.exit(0);
 		}
 	}
 

--- a/Baselet/src/com/baselet/gui/standalone/StandaloneGUIBuilder.java
+++ b/Baselet/src/com/baselet/gui/standalone/StandaloneGUIBuilder.java
@@ -62,7 +62,7 @@ public class StandaloneGUIBuilder extends BaseGUIBuilder {
 		mainFrame.addKeyListener(new GUIListener());
 		mainFrame.addKeyListener(new SearchKeyListener());
 		mainFrame.addWindowListener(new SwingWindowListener());
-		mainFrame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE); // must be EXIT_ON_CLOSE instead of DISPOSE_ON_CLOSE or otherwise the umlet process will remain running invisible in the background sometimes (see https://stackoverflow.com/questions/246228/why-does-my-application-still-run-after-closing-main-window)
+		mainFrame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
 		mainFrame.setBounds(Config.getInstance().getProgram_location().x, Config.getInstance().getProgram_location().y, Config.getInstance().getProgram_size().width, Config.getInstance().getProgram_size().height);
 		mainFrame.setTitle(Program.getInstance().getProgramName() + " - Free UML Tool for Fast UML Diagrams");
 


### PR DESCRIPTION
Handle close event completelly in closeWindow() instead of using the default close operation.

EXIT_ON_CLOSE will close the application and can't be canceled. So it will close the application if the 'X' was pressed. Calling System.exit(0) in StandaloneGUI.closeWindow() will give you the same behaviour as using EXIT_ON_CLOSE.