### PR TITLE
Fix #177: Umlet very slow on java 8

### DIFF
--- a/Baselet/exe/umlet.sh
+++ b/Baselet/exe/umlet.sh
@@ -9,6 +9,6 @@
 programDir=$(cd $(dirname $0);pwd)
 
 if [ $# -eq 1 ]
- then java -jar ${programDir}/umlet.jar -filename="$1"
- else java -jar ${programDir}/umlet.jar "$@"
+ then java -Dsun.java2d.xrender=f -jar ${programDir}/umlet.jar -filename="$1"
+ else java -Dsun.java2d.xrender=f -jar ${programDir}/umlet.jar "$@"
 fi


### PR DESCRIPTION
Workaround by disabling XRender.

See https://bugs.openjdk.java.net/browse/JDK-8068529