### PR TITLE
#273 Fix configfile location

### DIFF
--- a/Baselet/src/com/baselet/control/config/handler/ConfigHandler.java
+++ b/Baselet/src/com/baselet/control/config/handler/ConfigHandler.java
@@ -76,24 +76,13 @@ public class ConfigHandler {
 	private static Properties props;
 
 	public static void loadConfig() {
-		Config cfg = Config.getInstance();
 
+		props = loadProperties();
 		configfile = new File(Path.osCompatibleConfig());
-		if (!configfile.exists()) {
+		if (props.isEmpty())
 			return;
-		}
 
-		props = new Properties();
-		try {
-			FileInputStream inputStream = new FileInputStream(Path.osCompatibleConfig());
-			try {
-				props.load(inputStream);
-			} finally {
-				inputStream.close();
-			}
-		} catch (Exception ex) {
-			ex.printStackTrace();
-		}
+		Config cfg = Config.getInstance();
 
 		cfg.setProgramVersion(getStringProperty(PROGRAM_VERSION, Program.getInstance().getVersion()));
 		cfg.setDefaultFontsize(getIntProperty(DEFAULT_FONTSIZE, cfg.getDefaultFontsize()));
@@ -192,8 +181,7 @@ public class ConfigHandler {
 				Frame topContainer = ((StandaloneGUI) gui).getMainFrame();
 				if ((topContainer.getExtendedState() & Frame.MAXIMIZED_BOTH) == Frame.MAXIMIZED_BOTH) {
 					props.setProperty(START_MAXIMIZED, "true");
-				}
-				// Otherwise the size and the location is written in the cfg
+				} // Otherwise the size and the location is written in the cfg
 				else {
 					props.setProperty(START_MAXIMIZED, "false");
 					props.setProperty(PROGRAM_SIZE, topContainer.getSize().width + "," + topContainer.getSize().height);
@@ -211,7 +199,7 @@ public class ConfigHandler {
 
 			/* MAIL */
 			ConfigMail cfgMail = ConfigMail.getInstance();
-			if (!!cfgMail.getMail_smtp().isEmpty()) {
+			if (! !cfgMail.getMail_smtp().isEmpty()) {
 				props.setProperty(MAIL_SMTP, cfgMail.getMail_smtp());
 			}
 			props.setProperty(MAIL_SMTP_AUTH, Boolean.toString(cfgMail.isMail_smtp_auth()));
@@ -255,6 +243,34 @@ public class ConfigHandler {
 		} catch (IOException ex) {
 			ex.printStackTrace();
 		}
+	}
+
+	private static Properties loadProperties() {
+		Properties result = new Properties();
+
+		if (Path.hasOsCompatibleConfig())
+			result = loadPropertiesFromFile(Path.osCompatibleConfig());
+		else if (Path.hasUserHomeConfig())
+			result = loadPropertiesFromFile(Path.userHomeConfig());
+		
+		return result;
+	}
+
+	private static Properties loadPropertiesFromFile(String filePath) {
+		Properties result = new Properties();
+
+		try {
+			FileInputStream inputStream = new FileInputStream(filePath);
+			try {
+				result.load(inputStream);
+			} finally {
+				inputStream.close();
+			}
+		} catch (Exception ex) {
+			ex.printStackTrace();
+		}
+
+		return result;
 	}
 
 	private static int getIntProperty(String key, int defaultValue) {

--- a/Baselet/src/com/baselet/control/config/handler/ConfigHandler.java
+++ b/Baselet/src/com/baselet/control/config/handler/ConfigHandler.java
@@ -78,14 +78,14 @@ public class ConfigHandler {
 	public static void loadConfig() {
 		Config cfg = Config.getInstance();
 
-		configfile = new File(Path.config());
+		configfile = new File(Path.osCompatibleConfig());
 		if (!configfile.exists()) {
 			return;
 		}
 
 		props = new Properties();
 		try {
-			FileInputStream inputStream = new FileInputStream(Path.config());
+			FileInputStream inputStream = new FileInputStream(Path.osCompatibleConfig());
 			try {
 				props.load(inputStream);
 			} finally {

--- a/Baselet/src/com/baselet/control/config/handler/ConfigHandler.java
+++ b/Baselet/src/com/baselet/control/config/handler/ConfigHandler.java
@@ -72,13 +72,11 @@ public class ConfigHandler {
 	private static final String GENERATE_CLASS_SIGNATURES = "generate_class_signatures";
 	private static final String GENERATE_CLASS_SORTINGS = "generate_class_sortings";
 
-	private static File configfile;
 	private static Properties props;
 
 	public static void loadConfig() {
 
 		props = loadProperties();
-		configfile = new File(Path.osCompatibleConfig());
 		if (props.isEmpty())
 			return;
 
@@ -143,15 +141,12 @@ public class ConfigHandler {
 	}
 
 	public static void saveConfig(BaseGUI gui) {
-		Config cfg = Config.getInstance();
-
-		if (configfile == null) {
-			return;
-		}
 		try {
-			Utils.safeDeleteFile(configfile, false);
+                      	File configfile = new File(Path.osConformConfig());
+                        Utils.safeDeleteFile(configfile, false);
 			Utils.safeCreateFile(configfile, false);
 
+                        Config cfg = Config.getInstance();
 			Properties props = new Properties();
 
 			props.setProperty(PROGRAM_VERSION, Program.getInstance().getVersion());
@@ -248,10 +243,10 @@ public class ConfigHandler {
 	private static Properties loadProperties() {
 		Properties result = new Properties();
 
-		if (Path.hasOsCompatibleConfig())
-			result = loadPropertiesFromFile(Path.osCompatibleConfig());
-		else if (Path.hasUserHomeConfig())
-			result = loadPropertiesFromFile(Path.userHomeConfig());
+		if (Path.hasOsConformConfig())
+			result = loadPropertiesFromFile(Path.osConformConfig());
+		else if (Path.hasLegacyConfig())
+			result = loadPropertiesFromFile(Path.legacyConfig());
 		
 		return result;
 	}

--- a/Baselet/src/com/baselet/control/util/Path.java
+++ b/Baselet/src/com/baselet/control/util/Path.java
@@ -1,5 +1,7 @@
 package com.baselet.control.util;
 
+import com.baselet.control.constants.SystemInfo;
+import com.baselet.control.enums.Os;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -15,10 +17,51 @@ public class Path {
 	private static String tempDir;
 	private static String homeProgramDir;
 
+	public static String osCompatibleConfig() {
+		return new File(osCompatibleConfigDirectory(), configFileSubPath()).getPath();
+	}
+	
 	public static String config() {
 		return userHome() + File.separator + Program.getInstance().getConfigName();
 	}
 
+	private static String osCompatibleConfigDirectory() {
+		String configDir = userHomeDirectory();
+        
+		if (SystemInfo.OS == Os.WINDOWS) {
+		    configDir = windowsCompatibleConfigDirectory();
+		} else if (SystemInfo.OS == Os.MAC) {
+		    configDir = macOSXCompatibleConfigDirectory();	// this would not work for classic MacOS
+		} else if (SystemInfo.OS == Os.LINUX || SystemInfo.OS == Os.UNIX) {
+		    configDir = xgdCompatibleConfigDirectory();
+		}
+
+		return configDir;
+	}
+	private static String windowsCompatibleConfigDirectory() {
+		String configPath = System.getenv("LOCALAPPDATA");
+		if (configPath == null)
+		    configPath = userHomeDirectory();
+        
+		return configPath;
+	}
+	private static String macOSXCompatibleConfigDirectory() {
+		return new File(userHomeDirectory(), "Library/Preferences").getPath();
+	}
+	private static String xgdCompatibleConfigDirectory() {
+		String configPath = System.getenv("XDG_CONFIG_HOME");
+		if (configPath == null)
+		    configPath = new File(userHomeDirectory(), ".config").getPath();
+
+		return configPath;
+	}
+	private static String userHomeDirectory() {
+		return System.getProperty("user.home");
+	}
+	private static String configFileSubPath() {
+		return new File(Program.getInstance().getProgramName(), Program.getInstance().getConfigName()).getPath();
+	}
+		
 	private static String userHome() {
 		String homeDir = userHomeBase();
 		if (!homeDir.endsWith(File.separator)) {

--- a/Baselet/src/com/baselet/control/util/Path.java
+++ b/Baselet/src/com/baselet/control/util/Path.java
@@ -17,6 +17,16 @@ public class Path {
 	private static String tempDir;
 	private static String homeProgramDir;
 
+	public static boolean hasOsCompatibleConfig() {
+		File file = new File(osCompatibleConfig());
+		return file.exists();
+	}
+
+	public static boolean hasUserHomeConfig() {
+		File file = new File(userHomeConfig());
+		return file.exists();
+	}
+
 	public static String osCompatibleConfig() {
 		String programConfigDir = combine(osCompatibleConfigDirectory(), Program.getInstance().getProgramName());
 		ensureDirectoryIsExisting(programConfigDir);

--- a/Baselet/src/com/baselet/control/util/Path.java
+++ b/Baselet/src/com/baselet/control/util/Path.java
@@ -24,7 +24,7 @@ public class Path {
 		return combine(programConfigDir, Program.getInstance().getConfigName());
 	}
 	
-	public static String config() {
+	public static String userHomeConfig() {
 		String programConfigDirectory = combine(userHomeDirectory(), Program.getInstance().getProgramName());
 
 		return combine(programConfigDirectory, Program.getInstance().getConfigName());
@@ -42,7 +42,7 @@ public class Path {
 		if (SystemInfo.OS == Os.WINDOWS) {
 		    configDir = windowsCompatibleConfigDirectory();
 		} else if (SystemInfo.OS == Os.MAC) {
-		    configDir = macOSXCompatibleConfigDirectory();	// this would not work for classic MacOS
+		    configDir = macOSXCompatibleConfigDirectory();
 		} else if (SystemInfo.OS == Os.LINUX || SystemInfo.OS == Os.UNIX) {
 		    configDir = xgdCompatibleConfigDirectory();
 		}
@@ -72,28 +72,6 @@ public class Path {
 		
 	private static String combine(String path, String childPath) {
 		return new File(path, childPath).getPath();
-	}
-	private static String userHome() {
-		String homeDir = userHomeBase();
-		if (!homeDir.endsWith(File.separator)) {
-			homeDir += File.separator;
-		}
-		File homeDirFile = new File(homeDir + Program.getInstance().getProgramName());
-		if (!homeDirFile.exists()) {
-			Utils.safeMkDir(homeDirFile, true);
-		}
-		return homeDirFile.getAbsolutePath();
-	}
-
-	private static String userHomeBase() {
-		try {
-			String xdgConfigHome = System.getenv("XDG_CONFIG_HOME"); // use env variable $XDG_CONFIG_HOME if it's set
-			if (xdgConfigHome != null) {
-				return xdgConfigHome;
-			}
-		} catch (Exception e) { /* if env variable cannot be read, ignore it */}
-
-		return System.getProperty("user.home");
 	}
 
 	public static String customElements() {

--- a/Baselet/src/com/baselet/control/util/Path.java
+++ b/Baselet/src/com/baselet/control/util/Path.java
@@ -18,13 +18,24 @@ public class Path {
 	private static String homeProgramDir;
 
 	public static String osCompatibleConfig() {
-		return new File(osCompatibleConfigDirectory(), configFileSubPath()).getPath();
+		String programConfigDir = combine(osCompatibleConfigDirectory(), Program.getInstance().getProgramName());
+		ensureDirectoryIsExisting(programConfigDir);
+
+		return combine(programConfigDir, Program.getInstance().getConfigName());
 	}
 	
 	public static String config() {
-		return userHome() + File.separator + Program.getInstance().getConfigName();
+		String programConfigDirectory = combine(userHomeDirectory(), Program.getInstance().getProgramName());
+
+		return combine(programConfigDirectory, Program.getInstance().getConfigName());
 	}
 
+	private static void ensureDirectoryIsExisting(String path) {
+		File file = new File(path);
+		if (!file.exists()) {
+			Utils.safeMkDir(file, true);
+		}
+	}
 	private static String osCompatibleConfigDirectory() {
 		String configDir = userHomeDirectory();
         
@@ -46,22 +57,22 @@ public class Path {
 		return configPath;
 	}
 	private static String macOSXCompatibleConfigDirectory() {
-		return new File(userHomeDirectory(), "Library/Preferences").getPath();
+		return combine(userHomeDirectory(), "Library/Preferences");
 	}
 	private static String xgdCompatibleConfigDirectory() {
 		String configPath = System.getenv("XDG_CONFIG_HOME");
 		if (configPath == null)
-		    configPath = new File(userHomeDirectory(), ".config").getPath();
+		    configPath = combine(userHomeDirectory(), ".config");
 
 		return configPath;
 	}
 	private static String userHomeDirectory() {
 		return System.getProperty("user.home");
 	}
-	private static String configFileSubPath() {
-		return new File(Program.getInstance().getProgramName(), Program.getInstance().getConfigName()).getPath();
-	}
 		
+	private static String combine(String path, String childPath) {
+		return new File(path, childPath).getPath();
+	}
 	private static String userHome() {
 		String homeDir = userHomeBase();
 		if (!homeDir.endsWith(File.separator)) {

--- a/Baselet/src/com/baselet/control/util/Path.java
+++ b/Baselet/src/com/baselet/control/util/Path.java
@@ -17,24 +17,24 @@ public class Path {
 	private static String tempDir;
 	private static String homeProgramDir;
 
-	public static boolean hasOsCompatibleConfig() {
-		File file = new File(osCompatibleConfig());
+	public static boolean hasOsConformConfig() {
+		File file = new File(osConformConfig());
 		return file.exists();
 	}
 
-	public static boolean hasUserHomeConfig() {
-		File file = new File(userHomeConfig());
+	public static boolean hasLegacyConfig() {
+		File file = new File(legacyConfig());
 		return file.exists();
 	}
 
-	public static String osCompatibleConfig() {
-		String programConfigDir = combine(osCompatibleConfigDirectory(), Program.getInstance().getProgramName());
+	public static String osConformConfig() {
+		String programConfigDir = combine(osConformConfigDirectory(), Program.getInstance().getProgramName());
 		ensureDirectoryIsExisting(programConfigDir);
 
 		return combine(programConfigDir, Program.getInstance().getConfigName());
 	}
 	
-	public static String userHomeConfig() {
+	public static String legacyConfig() {
 		String programConfigDirectory = combine(userHomeDirectory(), Program.getInstance().getProgramName());
 
 		return combine(programConfigDirectory, Program.getInstance().getConfigName());
@@ -46,30 +46,30 @@ public class Path {
 			Utils.safeMkDir(file, true);
 		}
 	}
-	private static String osCompatibleConfigDirectory() {
+	private static String osConformConfigDirectory() {
 		String configDir = userHomeDirectory();
         
 		if (SystemInfo.OS == Os.WINDOWS) {
-		    configDir = windowsCompatibleConfigDirectory();
+		    configDir = windowsConfigDirectory();
 		} else if (SystemInfo.OS == Os.MAC) {
-		    configDir = macOSXCompatibleConfigDirectory();
-		} else if (SystemInfo.OS == Os.LINUX || SystemInfo.OS == Os.UNIX) {
-		    configDir = xgdCompatibleConfigDirectory();
+		    configDir = macOSXConfigDirectory();
+		} else if (SystemInfo.OS == Os.LINUX || SystemInfo.OS == Os.UNIX) { 
+		    configDir = xgdConfigDirectory();
 		}
 
 		return configDir;
 	}
-	private static String windowsCompatibleConfigDirectory() {
+	private static String windowsConfigDirectory() {
 		String configPath = System.getenv("LOCALAPPDATA");
 		if (configPath == null)
 		    configPath = userHomeDirectory();
         
 		return configPath;
 	}
-	private static String macOSXCompatibleConfigDirectory() {
+	private static String macOSXConfigDirectory() {
 		return combine(userHomeDirectory(), "Library/Preferences");
 	}
-	private static String xgdCompatibleConfigDirectory() {
+	private static String xgdConfigDirectory() {
 		String configPath = System.getenv("XDG_CONFIG_HOME");
 		if (configPath == null)
 		    configPath = combine(userHomeDirectory(), ".config");


### PR DESCRIPTION
Fix for issue #273. It is tested on Arch Linux and Windows 8. MacOSX can't be tested here because of missing a Mac :) . As Manuel suggested it tries to load from the old config location if the os conform config location isn't existing.