### PR TITLE
GWT: Codecompletion with Scrollbars

### DIFF
--- a/BaseletGWT/src/com/baselet/gwt/client/view/MainView.ui.xml
+++ b/BaseletGWT/src/com/baselet/gwt/client/view/MainView.ui.xml
@@ -40,6 +40,12 @@
 		    position: relative;
 		    top: 2px;
 		}
+		.propPanel{
+		    -webkit-box-sizing: border-box;
+		    -moz-box-sizing: border-box;
+		    box-sizing: border-box;
+		    resize: none;
+		}
 	</ui:style>
 	
 	<g:FocusPanel stylePrimaryName="mainView" ui:field="mainPanel">
@@ -87,7 +93,7 @@
 					<g:center>
 						<g:FlowPanel>
 							<g:HTML><div class='{style.propertiesTitle}'>Properties</div></g:HTML>
-							<o:PropertiesTextArea ui:field="propertiesPanel" height="100%" width="100%" />
+							<o:PropertiesTextArea ui:field="propertiesPanel" height="100%" width="100%" addStyleNames="{style.propPanel}" />
 						</g:FlowPanel>
 					</g:center>
 				</g:SplitLayoutPanel>

--- a/BaseletGWT/src/com/baselet/gwt/client/view/widgets/propertiespanel/MySuggestionDisplay.java
+++ b/BaseletGWT/src/com/baselet/gwt/client/view/widgets/propertiespanel/MySuggestionDisplay.java
@@ -46,7 +46,7 @@ public class MySuggestionDisplay extends DefaultSuggestionDisplay {
 	@Override
 	protected void showSuggestions(SuggestBox suggestBox, Collection<? extends Suggestion> suggestions, boolean isDisplayStringHTML, boolean isAutoSelectEnabled, SuggestionCallback callback) {
 		super.showSuggestions(suggestBox, suggestions, isDisplayStringHTML, isAutoSelectEnabled, callback);
-		getPopupPanel().getWidget().setWidth(suggestBox.getElement().getAbsoluteRight() - suggestBox.getAbsoluteLeft() - 40 + Unit.PX.getType());
+		getPopupPanel().getWidget().setWidth(suggestBox.getElement().getScrollWidth() + Unit.PX.getType());
 		if (isSuggestionListShowing()) {
 			popupHideTimer.cancel();
 			paletteShouldIgnoreMouseClicks = true;

--- a/BaseletGWT/src/com/baselet/gwt/client/view/widgets/propertiespanel/MySuggestionDisplay.java
+++ b/BaseletGWT/src/com/baselet/gwt/client/view/widgets/propertiespanel/MySuggestionDisplay.java
@@ -28,6 +28,7 @@ public class MySuggestionDisplay extends DefaultSuggestionDisplay {
 	 * padding from the browser frame to the top of the display box.
 	 */
 	private static final int DISPLAY_BOX_TOP_PADDING = 40;
+	private static final int DISPLAY_BOX_MIN_HEIGHT = 60;
 
 	private boolean paletteShouldIgnoreMouseClicks = false;
 	private final Timer popupHideTimer = new Timer() {
@@ -52,7 +53,8 @@ public class MySuggestionDisplay extends DefaultSuggestionDisplay {
 	@Override
 	protected void showSuggestions(SuggestBox suggestBox, Collection<? extends Suggestion> suggestions, boolean isDisplayStringHTML, boolean isAutoSelectEnabled, SuggestionCallback callback) {
 		getPopupPanel().getWidget().setWidth(suggestBox.getElement().getScrollWidth() + Unit.PX.getType());
-		getPopupPanel().getWidget().setHeight(suggestBox.getElement().getAbsoluteTop() - DISPLAY_BOX_TOP_PADDING + Unit.PX.getType());
+		getPopupPanel().getWidget().setHeight(Math.max(DISPLAY_BOX_MIN_HEIGHT,
+				suggestBox.getElement().getAbsoluteTop() - DISPLAY_BOX_TOP_PADDING) + Unit.PX.getType());
 		super.showSuggestions(suggestBox, suggestions, isDisplayStringHTML, isAutoSelectEnabled, callback);
 		if (isSuggestionListShowing()) {
 			popupHideTimer.cancel();

--- a/BaseletGWT/src/com/baselet/gwt/client/view/widgets/propertiespanel/MySuggestionDisplay.java
+++ b/BaseletGWT/src/com/baselet/gwt/client/view/widgets/propertiespanel/MySuggestionDisplay.java
@@ -56,7 +56,6 @@ public class MySuggestionDisplay extends DefaultSuggestionDisplay {
 	@Override
 	protected Widget decorateSuggestionList(Widget suggestionList) {
 		suggestionList = new ScrollPanel(suggestionList);
-		// ((ScrollPanel) suggestionList).setWidth("100px");
 		return super.decorateSuggestionList(suggestionList);
 	}
 

--- a/BaseletGWT/src/com/baselet/gwt/client/view/widgets/propertiespanel/MySuggestionDisplay.java
+++ b/BaseletGWT/src/com/baselet/gwt/client/view/widgets/propertiespanel/MySuggestionDisplay.java
@@ -2,14 +2,17 @@ package com.baselet.gwt.client.view.widgets.propertiespanel;
 
 import java.util.Collection;
 
+import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.PopupPanel;
+import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.user.client.ui.SuggestBox;
 import com.google.gwt.user.client.ui.SuggestBox.DefaultSuggestionDisplay;
 import com.google.gwt.user.client.ui.SuggestBox.SuggestionCallback;
 import com.google.gwt.user.client.ui.SuggestOracle.Suggestion;
+import com.google.gwt.user.client.ui.Widget;
 
 /**
  * The purpose of this class is to avoid mouse interaction with the palette as long as the suggestbox is visible
@@ -21,7 +24,7 @@ import com.google.gwt.user.client.ui.SuggestOracle.Suggestion;
  */
 public class MySuggestionDisplay extends DefaultSuggestionDisplay {
 	private boolean paletteShouldIgnoreMouseClicks = false;
-	private Timer popupHideTimer = new Timer() {
+	private final Timer popupHideTimer = new Timer() {
 		@Override
 		public void run() {
 			paletteShouldIgnoreMouseClicks = false;
@@ -43,10 +46,18 @@ public class MySuggestionDisplay extends DefaultSuggestionDisplay {
 	@Override
 	protected void showSuggestions(SuggestBox suggestBox, Collection<? extends Suggestion> suggestions, boolean isDisplayStringHTML, boolean isAutoSelectEnabled, SuggestionCallback callback) {
 		super.showSuggestions(suggestBox, suggestions, isDisplayStringHTML, isAutoSelectEnabled, callback);
+		getPopupPanel().getWidget().setWidth(suggestBox.getElement().getAbsoluteRight() - suggestBox.getAbsoluteLeft() - 40 + Unit.PX.getType());
 		if (isSuggestionListShowing()) {
 			popupHideTimer.cancel();
 			paletteShouldIgnoreMouseClicks = true;
 		}
+	}
+
+	@Override
+	protected Widget decorateSuggestionList(Widget suggestionList) {
+		suggestionList = new ScrollPanel(suggestionList);
+		// ((ScrollPanel) suggestionList).setWidth("100px");
+		return super.decorateSuggestionList(suggestionList);
 	}
 
 	public boolean getPaletteShouldIgnoreMouseClicks() {

--- a/BaseletGWT/src/com/baselet/gwt/client/view/widgets/propertiespanel/MySuggestionDisplay.java
+++ b/BaseletGWT/src/com/baselet/gwt/client/view/widgets/propertiespanel/MySuggestionDisplay.java
@@ -23,6 +23,12 @@ import com.google.gwt.user.client.ui.Widget;
  * This alternative approach uses a timer to avoid palette interaction for some time after the popup closes to make sure mouseevents can be avoided
  */
 public class MySuggestionDisplay extends DefaultSuggestionDisplay {
+
+	/**
+	 * padding from the browser frame to the top of the display box.
+	 */
+	private static final int DISPLAY_BOX_TOP_PADDING = 40;
+
 	private boolean paletteShouldIgnoreMouseClicks = false;
 	private final Timer popupHideTimer = new Timer() {
 		@Override
@@ -45,8 +51,9 @@ public class MySuggestionDisplay extends DefaultSuggestionDisplay {
 
 	@Override
 	protected void showSuggestions(SuggestBox suggestBox, Collection<? extends Suggestion> suggestions, boolean isDisplayStringHTML, boolean isAutoSelectEnabled, SuggestionCallback callback) {
-		super.showSuggestions(suggestBox, suggestions, isDisplayStringHTML, isAutoSelectEnabled, callback);
 		getPopupPanel().getWidget().setWidth(suggestBox.getElement().getScrollWidth() + Unit.PX.getType());
+		getPopupPanel().getWidget().setHeight(suggestBox.getElement().getAbsoluteTop() - DISPLAY_BOX_TOP_PADDING + Unit.PX.getType());
+		super.showSuggestions(suggestBox, suggestions, isDisplayStringHTML, isAutoSelectEnabled, callback);
 		if (isSuggestionListShowing()) {
 			popupHideTimer.cancel();
 			paletteShouldIgnoreMouseClicks = true;


### PR DESCRIPTION
The code completion display window is now the size of the Properties Panel.
Properties Panel now fit better into the parent (the right scroll bar was truncated)
remaining small bug: "Properties" text is pushed out of sight if the full height of the properties panel is used because the panel is 100% the height of the parent.