### PR TITLE
Custom Elements: Transparency support

### DIFF
--- a/Baselet/palettes/Custom Drawings.uxf
+++ b/Baselet/palettes/Custom Drawings.uxf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<diagram program="umlet" version="13.3">
+<diagram program="umlet" version="14.1">
   <zoom_level>10</zoom_level>
   <element>
     <id>UMLNote</id>
@@ -121,8 +121,10 @@ drawRectangle(10,10,width-20,height-20) //fg= bg= lt= lw= //Parameters (x, y, wi
     <panel_attributes>On the left side a Union symbol
 Middle and right,shows the 
 difference between open and closed
+transparency=80
+bg=red
 customelement=
-drawArc(10,40,30,50,180,180,true) //fg= bg= lt= lw= //Parameters (x, y, width, height, start, extent, open)
+drawArc(10,40,30,50,180,180,true) transparency=100
 
 drawArc(100,60,30,45,130,280,true) bg=gray
 drawArc(150,60,30,45,130,280,false) bg=gray
@@ -135,7 +137,7 @@ drawArc(150,60,30,45,130,280,false) bg=gray
       <x>20</x>
       <y>510</y>
       <w>290</w>
-      <h>110</h>
+      <h>120</h>
     </coordinates>
     <panel_attributes>
 Draw inner rectangle similar
@@ -169,9 +171,9 @@ drawRectangleRound(10,10,width-20,height-20,10) //fg= bg= lt= lw= //Parameters (
     <id>UMLClass</id>
     <coordinates>
       <x>340</x>
-      <y>350</y>
+      <y>340</y>
       <w>210</w>
-      <h>270</h>
+      <h>290</h>
     </coordinates>
     <panel_attributes>Some arbitrary figures to show
 coloring and line type and width
@@ -185,17 +187,25 @@ drawRectangleRound(120,45,50,50,5) fg=orange bg=blue lt=:
 //gren point line
 drawLine(50,100,170,130)fg=green lt=..
 
-//circle with dashed border
-drawCircle(75,150,25) fg=black bg=yellow lw=2 lt=.
+//very transparent circle with dashed border
+drawCircle(75,150,25) fg=black bg=yellow lw=2 lt=. transparency=80
 
 //Ellipse with backgroundcolor from HEX string
 drawEllipse(120,150,70,40) fg=cyan bg=#FFC000
 
-//drawing a Circle without border using drawArc
-drawArc(50,200,50,50,0,360,true) lw=0 bg=red
+//drawing a solid Circle without border using drawArc
+drawArc(50,180,50,50,0,360,true) lw=0 bg=red transparency=0
 
 //a pie
 drawArc(80,200,120,40,0,30,false) fg=black bg=red lt=.
+
+//paint over other elements, to from complex figures
+drawRectangle(10,240,60,40) bg=blue transparency=0 lw=0
+drawCircle(40,260,15) bg=white transparency=0 lw=0
+
+drawRectangle(100,240,60,40) bg=red transparency=0
+drawCircle(100,240,15) bg=white transparency=0 lw=1 fg=white
+drawRectangle(130,260,31,21) bg=white transparency=0 lw=1 fg=white
 </panel_attributes>
     <additional_attributes/>
   </element>
@@ -205,7 +215,7 @@ drawArc(80,200,120,40,0,30,false) fg=black bg=red lt=.
       <x>340</x>
       <y>240</y>
       <w>210</w>
-      <h>100</h>
+      <h>90</h>
     </coordinates>
     <panel_attributes>        Drawing 2 parallel lines
 customelement=
@@ -260,24 +270,24 @@ drawLine(x1,y1,x2,y2) // parameters are doubles
 -
 drawRectangle(x,y,width,height) // parameters are doubles
 - draws a rectangle with the top left corner at (x,y)
-- can overwrite fg, bg, lt, lw
+- can overwrite fg, bg, lt, lw, transparency
 -
 drawRectangleRound(x,y,width,height radius) // parameters are doubles
 - draws a round rectangle with the top left corner at (x,y)
 - the corners have the given radius
-- can overwrite fg, bg, lt, lw
+- can overwrite fg, bg, lt, lw, transparency
 -
 drawCircle(x,y,radius) // parameters are doubles
 - draws a cricle with the center at (x,y) and the given radius
-- can overwrite fg, bg, lt, lw
+- can overwrite fg, bg, lt, lw, transparency
 -
 drawEllipse(x,y,width,height) // parameters are doubles
 - draws an ellipse where the top left corner of the surrounding rectangle is at (x,y)
-- can overwrite fg, bg, lt, lw
+- can overwrite fg, bg, lt, lw, transparency
 -
 drawArc(x,y,width,height,start,extent,open) // first 6 parameters are doubles, the last is a boolean (true or false)
 - draws an elliptical arc where the top left corner of the surrounding rectangle is at (x,y). This arc starts at &lt;start&gt; degrees and ends at &lt;start&gt;+&lt;extent&gt; degrees. If open is false two border lines are drawn from the center to the arc otherwise the arc is filled as there would exist a line between the two endpoints.
-- can overwrite fg, bg, lt, lw
+- can overwrite fg, bg, lt, lw, transparency
 -
 drawText(Text,x,y,horizontal alignment) // Parameters: String, double, double, HAlignment
 - HAlignment can be one of the following: left, right or center

--- a/BaseletElements/src/com/baselet/element/facet/customdrawings/CustomDrawingParser.jj
+++ b/BaseletElements/src/com/baselet/element/facet/customdrawings/CustomDrawingParser.jj
@@ -15,7 +15,7 @@ import com.baselet.control.enums.AlignHorizontal;
 import com.baselet.control.enums.LineType;
 import com.baselet.diagram.draw.DrawHandler;
 import com.baselet.diagram.draw.helper.ColorOwn;
-import com.baselet.diagram.draw.helper.ColorOwn.Transparency;
+import com.baselet.element.facet.customdrawings.CustomDrawingParserRuntimeException;
 
 public abstract class CustomDrawingParser {
 	// JavaCC doesn't support user enriched constructors (adding additional parameters)
@@ -73,6 +73,7 @@ TOKEN :    // defines token names
 	| < BG: "bg=" >
 	| < LT: "lt=" >
 	| < LW: "lw=" >
+	| < TRANSPARENCY: "transparency=" >
 }
 
 // more general Tokens
@@ -157,6 +158,7 @@ void drawRectangle() :
 		| callStack = bg(callStack)
 		| callStack = lt(callStack)
 		| callStack = lw(callStack)
+		| callStack = transparency(callStack)
 	)*
    { callStack.run(); }
 }
@@ -182,6 +184,7 @@ void drawRectangleRound() :
 		| callStack = bg(callStack)
 		| callStack = lt(callStack)
 		| callStack = lw(callStack)
+		| callStack = transparency(callStack)
 	)*
    { callStack.run(); }
 }
@@ -204,6 +207,7 @@ void drawCircle() :
 		| callStack = bg(callStack)
 		| callStack = lt(callStack)
 		| callStack = lw(callStack)
+		| callStack = transparency(callStack)
 	)*
    { callStack.run(); }
 }
@@ -227,6 +231,7 @@ void drawEllipse() :
 		| callStack = bg(callStack)
 		| callStack = lt(callStack)
 		| callStack = lw(callStack)
+		| callStack = transparency(callStack)
 	)*
    { callStack.run(); }
 }
@@ -254,6 +259,7 @@ void drawArc() :
 		| callStack = bg(callStack)
 		| callStack = lt(callStack)
 		| callStack = lw(callStack)
+		| callStack = transparency(callStack)
 	)*
    { callStack.run(); }
 }
@@ -285,16 +291,14 @@ void drawText() :
  * sets the foreground color
  */
 RecRunnable fg(RecRunnable inner) :
-{ final ColorOwn newColor;}
+{ final String newColor;}
 {
-	<FG> newColor = colorOwn(Transparency.FOREGROUND) {return new RecRunnable(inner) {
+	<FG> newColor = colorOwn() {return new RecRunnable(inner) {
 		public void run(){
-			//System.out.println("pre FG");
 			ColorOwn oldColor = getDrawHandler().getForegroundColor();
 			getDrawHandler().setForegroundColor(newColor);
 			runInner();
 			getDrawHandler().setForegroundColor(oldColor);
-			//System.out.println("post FG");
 		}
 	};}
 }
@@ -303,16 +307,14 @@ RecRunnable fg(RecRunnable inner) :
  * sets the background color
  */
 RecRunnable bg(RecRunnable inner) :
-{ final ColorOwn newColor;}
+{ final String newColor;}
 {
-	<BG> newColor = colorOwn(Transparency.BACKGROUND) {return new RecRunnable(inner) {
+	<BG> newColor = colorOwn() {return new RecRunnable(inner) {
 		public void run(){
-			//System.out.println("pre BG");
 			ColorOwn oldColor = getDrawHandler().getBackgroundColor();
-			getDrawHandler().setBackgroundColor(newColor);
+			getDrawHandler().setBackgroundColorAndKeepTransparency(newColor);
 			runInner();
 			getDrawHandler().setBackgroundColor(oldColor);
-			//System.out.println("post BG");
 		}
 	};}
 }
@@ -324,13 +326,13 @@ RecRunnable bg(RecRunnable inner) :
  * containing exactly 6 hexadecimal digits
  * (eg."#CAFFEE")
  */
-ColorOwn colorOwn(Transparency transparency) :
-{ ColorOwn value;}
+String colorOwn() :
+{}
 {
 	(
-		<COLOR_OWN_NAME> { value = ColorOwn.forString(token.image, transparency); } /* could be split up into color name Tokens */
-		| <COLOR_OWN_HEX> { value = ColorOwn.forString(token.image, transparency); }
-	) {return value;}
+		<COLOR_OWN_NAME>
+		| <COLOR_OWN_HEX>
+	) {return token.image;}
 }
 
 /**
@@ -341,12 +343,10 @@ RecRunnable lt(RecRunnable inner) :
 {
 	<LT> newLineType = lineType() {return new RecRunnable(inner) {
 		public void run() {
-			//System.out.println("pre LT");
 			LineType oldLineType = getDrawHandler().getLineType();
 			getDrawHandler().setLineType(newLineType);
 			runInner();
 			getDrawHandler().setLineType(oldLineType);
-			//System.out.println("post LT");
 		}
 	};}
 }
@@ -372,12 +372,32 @@ RecRunnable lw(RecRunnable inner) :
 {
 	<LW> newLineWidth = unsignedDoubleConstant() {return new RecRunnable(inner) {
 		public void run() {
-			//System.out.println("pre LW");
 			double oldLineWidth = getDrawHandler().getLineWidth();
 			getDrawHandler().setLineWidth(newLineWidth);
 			runInner();
 			getDrawHandler().setLineWidth(oldLineWidth);
-			//System.out.println("post LW");
+		}
+	};}
+}
+
+/**
+ * sets the transparency (background only)
+ */
+RecRunnable transparency(RecRunnable inner) :
+{ final double transparencyVal;}
+{
+	< TRANSPARENCY > transparencyVal = unsignedDoubleConstant()
+	{
+		if(transparencyVal < 0 || transparencyVal > 100) {
+			throw new CustomDrawingParserRuntimeException("The transparency value must be between 0 and 100");		}
+		return new RecRunnable(inner) {
+		public void run(){
+			ColorOwn oldColor = getDrawHandler().getBackgroundColor();
+			double colorTransparencyValue = 255 - transparencyVal * 2.55; /* ColorOwn has 0 for full transparency and 255 for no transparency */
+			ColorOwn bgColor = getDrawHandler().getBackgroundColor();
+			getDrawHandler().setBackgroundColor(bgColor.transparency((int) colorTransparencyValue));
+			runInner();
+			getDrawHandler().setBackgroundColor(oldColor);
 		}
 	};}
 }

--- a/BaseletGWT/src/com/baselet/gwt/client/view/palettes/Custom Drawings.uxf
+++ b/BaseletGWT/src/com/baselet/gwt/client/view/palettes/Custom Drawings.uxf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<diagram program="umlet" version="13.3">
+<diagram program="umlet" version="14.1">
   <zoom_level>10</zoom_level>
   <element>
     <id>UMLNote</id>
@@ -121,8 +121,10 @@ drawRectangle(10,10,width-20,height-20) //fg= bg= lt= lw= //Parameters (x, y, wi
     <panel_attributes>On the left side a Union symbol
 Middle and right,shows the 
 difference between open and closed
+transparency=80
+bg=red
 customelement=
-drawArc(10,40,30,50,180,180,true) //fg= bg= lt= lw= //Parameters (x, y, width, height, start, extent, open)
+drawArc(10,40,30,50,180,180,true) transparency=100
 
 drawArc(100,60,30,45,130,280,true) bg=gray
 drawArc(150,60,30,45,130,280,false) bg=gray
@@ -135,7 +137,7 @@ drawArc(150,60,30,45,130,280,false) bg=gray
       <x>20</x>
       <y>510</y>
       <w>290</w>
-      <h>110</h>
+      <h>120</h>
     </coordinates>
     <panel_attributes>
 Draw inner rectangle similar
@@ -169,9 +171,9 @@ drawRectangleRound(10,10,width-20,height-20,10) //fg= bg= lt= lw= //Parameters (
     <id>UMLClass</id>
     <coordinates>
       <x>340</x>
-      <y>350</y>
+      <y>340</y>
       <w>210</w>
-      <h>270</h>
+      <h>290</h>
     </coordinates>
     <panel_attributes>Some arbitrary figures to show
 coloring and line type and width
@@ -185,17 +187,25 @@ drawRectangleRound(120,45,50,50,5) fg=orange bg=blue lt=:
 //gren point line
 drawLine(50,100,170,130)fg=green lt=..
 
-//circle with dashed border
-drawCircle(75,150,25) fg=black bg=yellow lw=2 lt=.
+//very transparent circle with dashed border
+drawCircle(75,150,25) fg=black bg=yellow lw=2 lt=. transparency=80
 
 //Ellipse with backgroundcolor from HEX string
 drawEllipse(120,150,70,40) fg=cyan bg=#FFC000
 
-//drawing a Circle without border using drawArc
-drawArc(50,200,50,50,0,360,true) lw=0 bg=red
+//drawing a solid Circle without border using drawArc
+drawArc(50,180,50,50,0,360,true) lw=0 bg=red transparency=0
 
 //a pie
 drawArc(80,200,120,40,0,30,false) fg=black bg=red lt=.
+
+//paint over other elements, to from complex figures
+drawRectangle(10,240,60,40) bg=blue transparency=0 lw=0
+drawCircle(40,260,15) bg=white transparency=0 lw=0
+
+drawRectangle(100,240,60,40) bg=red transparency=0
+drawCircle(100,240,15) bg=white transparency=0 lw=1 fg=white
+drawRectangle(130,260,31,21) bg=white transparency=0 lw=1 fg=white
 </panel_attributes>
     <additional_attributes/>
   </element>
@@ -205,7 +215,7 @@ drawArc(80,200,120,40,0,30,false) fg=black bg=red lt=.
       <x>340</x>
       <y>240</y>
       <w>210</w>
-      <h>100</h>
+      <h>90</h>
     </coordinates>
     <panel_attributes>        Drawing 2 parallel lines
 customelement=
@@ -260,24 +270,24 @@ drawLine(x1,y1,x2,y2) // parameters are doubles
 -
 drawRectangle(x,y,width,height) // parameters are doubles
 - draws a rectangle with the top left corner at (x,y)
-- can overwrite fg, bg, lt, lw
+- can overwrite fg, bg, lt, lw, transparency
 -
 drawRectangleRound(x,y,width,height radius) // parameters are doubles
 - draws a round rectangle with the top left corner at (x,y)
 - the corners have the given radius
-- can overwrite fg, bg, lt, lw
+- can overwrite fg, bg, lt, lw, transparency
 -
 drawCircle(x,y,radius) // parameters are doubles
 - draws a cricle with the center at (x,y) and the given radius
-- can overwrite fg, bg, lt, lw
+- can overwrite fg, bg, lt, lw, transparency
 -
 drawEllipse(x,y,width,height) // parameters are doubles
 - draws an ellipse where the top left corner of the surrounding rectangle is at (x,y)
-- can overwrite fg, bg, lt, lw
+- can overwrite fg, bg, lt, lw, transparency
 -
 drawArc(x,y,width,height,start,extent,open) // first 6 parameters are doubles, the last is a boolean (true or false)
 - draws an elliptical arc where the top left corner of the surrounding rectangle is at (x,y). This arc starts at &lt;start&gt; degrees and ends at &lt;start&gt;+&lt;extent&gt; degrees. If open is false two border lines are drawn from the center to the arc otherwise the arc is filled as there would exist a line between the two endpoints.
-- can overwrite fg, bg, lt, lw
+- can overwrite fg, bg, lt, lw, transparency
 -
 drawText(Text,x,y,horizontal alignment) // Parameters: String, double, double, HAlignment
 - HAlignment can be one of the following: left, right or center


### PR DESCRIPTION
Added support for a transparency= option to all commands which support bg=.
Fixed the bg= option so it also supports the transparency specified by the user as normal diagram option.