### PR TITLE
Autoresize refactoring

### DIFF
--- a/BaseletElements/src/com/baselet/element/NewGridElement.java
+++ b/BaseletElements/src/com/baselet/element/NewGridElement.java
@@ -347,12 +347,9 @@ public abstract class NewGridElement implements GridElement {
 	}
 
 	public void handleAutoresize(DimensionDouble necessaryElementDimension, AlignHorizontal alignHorizontal) {
-		double hSpaceLeftAndRight = drawer.getDistanceBorderToText() * 2;
-		double width = necessaryElementDimension.getWidth() + hSpaceLeftAndRight;
-		double height = necessaryElementDimension.getHeight() + drawer.textHeightMax() / 2;
 		Dimension realSize = getRealSize();
-		double diffw = width - realSize.width;
-		double diffh = height - realSize.height;
+		double diffw = necessaryElementDimension.getWidth() - realSize.width;
+		double diffh = necessaryElementDimension.getHeight() - realSize.height;
 
 		int diffwInt = SharedUtils.realignTo(false, unzoom(diffw), true, getGridSize());
 		int diffhInt = SharedUtils.realignTo(false, unzoom(diffh), true, getGridSize());

--- a/BaseletElements/src/com/baselet/element/PropertiesParser.java
+++ b/BaseletElements/src/com/baselet/element/PropertiesParser.java
@@ -35,7 +35,7 @@ public class PropertiesParser {
 
 		if (state.getElementStyle() == ElementStyle.AUTORESIZE) { // only in case of autoresize element, calculate the elementsize
 			double width = state.getCalculatedElementWidth();
-			double height = state.getTextPrintPosition() - state.getDrawer().textHeightMax(); // subtract 1x textheight to avoid making element too high (because the print-text pos is always on the bottom)
+			double height = state.getTextPrintPosition();
 			element.handleAutoresize(new DimensionDouble(width, height), state.getAlignment().getHorizontal());
 		}
 

--- a/BaseletElements/src/com/baselet/element/facet/common/TextPrintFacet.java
+++ b/BaseletElements/src/com/baselet/element/facet/common/TextPrintFacet.java
@@ -146,4 +146,20 @@ public class TextPrintFacet extends Facet {
 		return Priority.LOWEST; // only text not used by other facets should be printed
 	}
 
+	@Override
+	public void parsingFinished(PropertiesParserState state, List<String> handledLines) {
+		// adjust height only if autoresize is active, becauce other elements use the
+		// height of the text to position the text in the center e.g. UseCase
+		if (state.getElementStyle() == ElementStyle.AUTORESIZE) {
+			double heightDiff = -state.getDrawer().textHeightMax(); // subtract 1xtextheight to avoid making element too high (because the print-text pos is always on the bottom)
+			heightDiff = heightDiff + state.getDrawer().textHeightMax() / 2; // add a vertical border padding
+			// since the height is textPrintPosition + buffer.getTop() we need to adjust the textPrintPosition and not the buffer (which is set with the updateMinimumSize method)
+			state.increaseTextPrintPosition(heightDiff);
+
+			// add a horizontal border padding
+			double hSpaceLeftAndRight = state.getDrawer().getDistanceBorderToText() * 2;
+			state.updateMinimumWidth(state.getCalculatedElementWidth() + hSpaceLeftAndRight);
+		}
+	}
+
 }


### PR DESCRIPTION
moved the size adjustment for the TextPrintFacet, which apply if Autoresize is active, from the PropertiesParser and NewGridElement into the TextPrintFacet.parsingFinished method.
Compared old and new implementation, they seem to produce identical diagrams.