### PR TITLE
fix Eclipse Plugin Menu is gray until Diagram is reopened #53

### DIFF
--- a/Baselet/META-INF/MANIFEST.MF
+++ b/Baselet/META-INF/MANIFEST.MF
@@ -7,9 +7,12 @@ Bundle-SymbolicName: com.umlet.plugin;singleton:=true
 Bundle-Version: 14.1
 Bundle-Activator: com.baselet.plugin.MainPlugin
 Bundle-Vendor: http://www.umlet.com
-Require-Bundle: org.eclipse.ui,org.eclipse.ui.ide,org.eclipse.core.res
- ources,org.eclipse.core.runtime,org.eclipse.jdt.core;resolution:=opti
- onal
+Require-Bundle: org.eclipse.ui,
+ org.eclipse.ui.ide,
+ org.eclipse.core.resources,
+ org.eclipse.core.runtime,
+ org.eclipse.jdt.core;resolution:=optional,
+ org.eclipse.core.expressions
 Bundle-ClassPath: ., lib/autocomplete.jar, lib/batik-awt-util.jar, lib
  /batik-dom.jar, lib/batik-ext.jar, lib/batik-svggen.jar, lib/batik-ut
  il.jar, lib/batik-xml.jar, lib/bcel-5.2.jar, lib/commons-io-2.4.jar, 

--- a/Baselet/plugin.xml
+++ b/Baselet/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin>
+<plugin >
    <extension point="org.eclipse.ui.newWizards">
       <wizard
             name="Umlet diagram"
@@ -19,5 +19,10 @@
             extensions="uxf"
             default="false"
       />
+   </extension>
+   <extension point="org.eclipse.ui.menus">
+     <menuContribution
+            locationURI="menu:org.eclipse.ui.main.menu?after=additions"
+            class="com.baselet.plugin.gui.MenuContributor" />
    </extension>
 </plugin>

--- a/Baselet/src/com/baselet/plugin/gui/Contributor.java
+++ b/Baselet/src/com/baselet/plugin/gui/Contributor.java
@@ -1,23 +1,15 @@
 package com.baselet.plugin.gui;
 
 import java.util.Collection;
-import java.util.List;
 
 import org.eclipse.jface.action.Action;
-import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IAction;
-import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.IMenuManager;
-import org.eclipse.jface.action.MenuManager;
-import org.eclipse.jface.action.Separator;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IActionBars;
-import org.eclipse.ui.IWorkbenchActionConstants;
 import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.part.EditorActionBarContributor;
 
-import com.baselet.control.constants.MenuConstants;
-import com.baselet.control.enums.Program;
 import com.baselet.element.interfaces.GridElement;
 import com.baselet.gui.CurrentGui;
 import com.baselet.plugin.gui.EclipseGUI.Pane;
@@ -50,12 +42,8 @@ public class Contributor extends EditorActionBarContributor {
 	private IAction pasteActionCustomPanel;
 	private IAction selectAllActionCustomPanel;
 
-	private List<IAction> exportAsActionList;
-
 	private boolean customPanelEnabled;
 	private boolean custom_element_selected;
-
-	private IMenuManager zoomMenu;
 
 	public Contributor() {
 		customPanelEnabled = false;
@@ -109,52 +97,6 @@ public class Contributor extends EditorActionBarContributor {
 	@Override
 	public void contributeToMenu(IMenuManager manager) {
 		((EclipseGUI) CurrentGui.getInstance().getGui()).setContributor(this);
-
-		IMenuManager menu = new MenuManager(Program.getInstance().getProgramName().toString());
-		IMenuManager custom = new MenuManager(MenuConstants.CUSTOM_ELEMENTS);
-		IMenuManager help = new MenuManager(MenuConstants.HELP);
-		manager.appendToGroup(IWorkbenchActionConstants.MB_ADDITIONS, menu);
-
-		custom.add(customnew = menuFactory.createNewCustomElement());
-		custom.add(menuFactory.createNewCustomElementFromTemplate(this));
-		custom.add(new Separator());
-		custom.add(menuFactory.createCustomElementsTutorial());
-
-		help.add(menuFactory.createOnlineHelp());
-		help.add(menuFactory.createOnlineSampleDiagrams());
-		help.add(menuFactory.createVideoTutorial());
-		help.add(new Separator());
-		help.add(menuFactory.createProgramHomepage());
-		help.add(menuFactory.createRateProgram());
-		help.add(new Separator());
-		help.add(menuFactory.createAboutProgram());
-
-		menu.add(menuFactory.createGenerate());
-		menu.add(menuFactory.createGenerateOptions());
-
-		zoomMenu = menuFactory.createZoom();
-		menu.add(zoomMenu);
-
-		exportAsActionList = menuFactory.createExportAsActions();
-		IMenuManager export = new MenuManager("Export as");
-		for (IAction action : exportAsActionList) {
-			export.add(action);
-		}
-		menu.add(export);
-
-		menu.add(menuFactory.createEditCurrentPalette());
-		menu.add(custom);
-		menu.add(menuFactory.createMailTo());
-		menu.add(new Separator());
-		menu.add(help);
-		menu.add(menuFactory.createOptions());
-	}
-
-	public void setExportAsEnabled(boolean enabled) {
-		// AB: We cannot disable the MenuManager, so we have to disable every entry in the export menu :P
-		for (IAction action : exportAsActionList) {
-			action.setEnabled(enabled);
-		}
 	}
 
 	public void setPaste(boolean value) {
@@ -229,16 +171,4 @@ public class Contributor extends EditorActionBarContributor {
 		});
 	}
 
-	public void updateZoomMenuRadioButton(int newGridSize) {
-		for (IContributionItem item : zoomMenu.getItems()) {
-			IAction action = ((ActionContributionItem) item).getAction();
-			int actionGridSize = Integer.parseInt(action.getText().substring(0, action.getText().length() - 2));
-			if (actionGridSize == newGridSize) {
-				action.setChecked(true);
-			}
-			else {
-				action.setChecked(false);
-			}
-		}
-	}
 }

--- a/Baselet/src/com/baselet/plugin/gui/EclipseGUI.java
+++ b/Baselet/src/com/baselet/plugin/gui/EclipseGUI.java
@@ -41,6 +41,8 @@ public class EclipseGUI extends BaseGUI {
 	private final HashMap<DiagramHandler, Editor> diagrams;
 	private Contributor contributor;
 
+	private MenuContributor menuContributor;
+
 	public EclipseGUI(CanCloseProgram main) {
 		super(main);
 		diagrams = new HashMap<DiagramHandler, Editor>();
@@ -65,7 +67,9 @@ public class EclipseGUI extends BaseGUI {
 			return; // Possible if method is called at loading a palette
 		}
 		boolean enable = handler != null && !currentDiagram.getGridElements().isEmpty();
-		contributor.setExportAsEnabled(enable);
+		if (menuContributor != null) {
+			menuContributor.setExportAsEnabled(enable);
+		}
 	}
 
 	@Override
@@ -300,8 +304,8 @@ public class EclipseGUI extends BaseGUI {
 
 	@Override
 	public void setValueOfZoomDisplay(int i) {
-		if (contributor != null) {
-			contributor.updateZoomMenuRadioButton(i);
+		if (menuContributor != null) {
+			menuContributor.updateZoomMenuRadioButton(i);
 		}
 	}
 
@@ -338,5 +342,9 @@ public class EclipseGUI extends BaseGUI {
 	@Override
 	public boolean saveWindowSizeInConfig() {
 		return false;
+	}
+
+	public void setMenuContributor(MenuContributor menuContributor) {
+		this.menuContributor = menuContributor;
 	}
 }

--- a/Baselet/src/com/baselet/plugin/gui/MenuContributor.java
+++ b/Baselet/src/com/baselet/plugin/gui/MenuContributor.java
@@ -1,0 +1,130 @@
+package com.baselet.plugin.gui;
+
+import java.util.List;
+
+import org.eclipse.jface.action.ActionContributionItem;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.action.IContributionItem;
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.action.Separator;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IPartListener;
+import org.eclipse.ui.IPartService;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.menus.ExtensionContributionFactory;
+import org.eclipse.ui.menus.IContributionRoot;
+import org.eclipse.ui.services.IServiceLocator;
+
+import com.baselet.control.constants.MenuConstants;
+import com.baselet.control.enums.Program;
+import com.baselet.gui.CurrentGui;
+
+public class MenuContributor extends ExtensionContributionFactory {
+
+	// private IAction customnew;
+
+	private final MenuFactoryEclipse menuFactory = MenuFactoryEclipse.getInstance();
+	private IMenuManager zoomMenu;
+	private List<IAction> exportAsActionList;
+
+	@Override
+	public void createContributionItems(IServiceLocator serviceLocator, IContributionRoot contributionRoot) {
+		((EclipseGUI) CurrentGui.getInstance().getGui()).setMenuContributor(this);
+		final IMenuManager menu = new MenuManager(Program.getInstance().getProgramName().toString());
+
+		IMenuManager custom = new MenuManager(MenuConstants.CUSTOM_ELEMENTS);
+		IMenuManager help = new MenuManager(MenuConstants.HELP);
+
+		// custom.add(customnew = menuFactory.createNewCustomElement());
+		// custom.add(menuFactory.createNewCustomElementFromTemplate(this));
+		custom.add(new Separator());
+		custom.add(menuFactory.createCustomElementsTutorial());
+
+		help.add(menuFactory.createOnlineHelp());
+		help.add(menuFactory.createOnlineSampleDiagrams());
+		help.add(menuFactory.createVideoTutorial());
+		help.add(new Separator());
+		help.add(menuFactory.createProgramHomepage());
+		help.add(menuFactory.createRateProgram());
+		help.add(new Separator());
+		help.add(menuFactory.createAboutProgram());
+
+		menu.add(menuFactory.createGenerate());
+		menu.add(menuFactory.createGenerateOptions());
+
+		zoomMenu = menuFactory.createZoom();
+		menu.add(zoomMenu);
+
+		exportAsActionList = menuFactory.createExportAsActions();
+		IMenuManager export = new MenuManager("Export as");
+		for (IAction action : exportAsActionList) {
+			export.add(action);
+		}
+		menu.add(export);
+
+		menu.add(menuFactory.createEditCurrentPalette());
+		menu.add(custom);
+		menu.add(menuFactory.createMailTo());
+		menu.add(new Separator());
+		menu.add(help);
+		menu.add(menuFactory.createOptions());
+
+		// register top level menu
+		menu.setVisible(false);
+		// manager.appendToGroup(IWorkbenchActionConstants.MB_ADDITIONS, menu);
+		contributionRoot.addContributionItem(menu, null);
+
+		// register listener to switch visibility of menu
+		serviceLocator.getService(IPartService.class).addPartListener(new IPartListener() {
+
+			@Override
+			public void partOpened(IWorkbenchPart arg0) {}
+
+			@Override
+			public void partDeactivated(IWorkbenchPart arg0) {}
+
+			@Override
+			public void partClosed(IWorkbenchPart arg0) {
+				if (arg0 instanceof Editor) {
+					menu.setVisible(false);
+				}
+			}
+
+			@Override
+			public void partBroughtToTop(IWorkbenchPart arg0) {
+
+				if (arg0 instanceof IEditorPart) {
+					menu.setVisible(arg0 instanceof Editor);
+				}
+			}
+
+			@Override
+			public void partActivated(IWorkbenchPart arg0) {
+				if (arg0 instanceof IEditorPart) {
+					menu.setVisible(arg0 instanceof Editor);
+				}
+			}
+		});
+	}
+
+	public void setExportAsEnabled(boolean enabled) {
+		// AB: We cannot disable the MenuManager, so we have to disable every entry in the export menu :P
+		for (IAction action : exportAsActionList) {
+			action.setEnabled(enabled);
+		}
+	}
+
+	public void updateZoomMenuRadioButton(int newGridSize) {
+		for (IContributionItem item : zoomMenu.getItems()) {
+			IAction action = ((ActionContributionItem) item).getAction();
+			int actionGridSize = Integer.parseInt(action.getText().substring(0, action.getText().length() - 2));
+			if (actionGridSize == newGridSize) {
+				action.setChecked(true);
+			}
+			else {
+				action.setChecked(false);
+			}
+		}
+	}
+}


### PR DESCRIPTION
As far as I could see, menu items added via the EditorActionBarContributor are disabled automatically as soon as the editor loses focus, which happens if you click the Overview view or open the Options popup and close it again. Therefore I switched to a ExtensionContributionFactory and added a listener to show/hide the menu based on the editor shown. Fixes #53 