### PR TITLE
Add Clear Property Pane Key Shortcut

### DIFF
--- a/umlet-swing/src/main/java/com/baselet/gui/listener/GUIListener.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/listener/GUIListener.java
@@ -28,10 +28,18 @@ public class GUIListener implements KeyListener {
 
 		if (handler != null && !e.isAltDown() && !e.isAltGraphDown() /* && !e.isControlDown() && !e.isMetaDown() */) {
 
+            /**
+             * Shift + Enter: clears property panel and focus it
+             */
+            if(e.getKeyCode() == KeyEvent.VK_ENTER && e.isShiftDown()){
+                CurrentGui.getInstance().getGui().getPropertyPane().clearText();
+				CurrentGui.getInstance().getGui().focusPropertyPane();
+            }
+
 			/**
 			 * Enter: jumps directly into the diagram
 			 */
-			if (e.getKeyCode() == KeyEvent.VK_ENTER) {
+			else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
 				CurrentGui.getInstance().getGui().focusPropertyPane();
 			}
 

--- a/umlet-swing/src/main/java/com/baselet/gui/pane/OwnSyntaxPane.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/pane/OwnSyntaxPane.java
@@ -130,6 +130,10 @@ public class OwnSyntaxPane {
 		return textArea.getText();
 	}
 
+    public void clearText(){
+        textArea.setText(null);
+    }
+
 	public JPanel getPanel() {
 		return panel;
 	}


### PR DESCRIPTION
This commit adds a feature that I personally wanted to see. 

In the vanilla version, pressing **<ENTER>** with a element selected will focus the property pane.
This commit adds an extended version of this key shortcut that when you press **<ENTER + SHIFT>**,
it will clear the property pane and focus it. This is helpful in cases where you are copy + pasting elements, that will need to be cleared of their copied properties anyway. 
