### PR TITLE
Add save when focus lost

### DIFF
--- a/umlet-standalone/src/main/java/com/baselet/standalone/gui/SwingWindowListener.java
+++ b/umlet-standalone/src/main/java/com/baselet/standalone/gui/SwingWindowListener.java
@@ -2,9 +2,13 @@ package com.baselet.standalone.gui;
 
 import java.awt.event.WindowEvent;
 
+import com.baselet.diagram.DiagramHandler;
+import com.baselet.gui.BaseGUI;
 import com.baselet.gui.CurrentGui;
 
 public class SwingWindowListener implements java.awt.event.WindowListener {
+
+
 
 	public SwingWindowListener() {}
 
@@ -20,7 +24,12 @@ public class SwingWindowListener implements java.awt.event.WindowListener {
 	}
 
 	@Override
-	public void windowDeactivated(WindowEvent arg0) {}
+	public void windowDeactivated(WindowEvent arg0) {
+        BaseGUI gui = CurrentGui.getInstance().getGui();
+		DiagramHandler diagramHandler = gui.getCurrentDiagram().getHandler();
+		if(diagramHandler.isFileSaved())
+            diagramHandler.doSave();
+    }
 
 	@Override
 	public void windowDeiconified(WindowEvent arg0) {}

--- a/umlet-swing/src/main/java/com/baselet/diagram/DiagramHandler.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/DiagramHandler.java
@@ -135,6 +135,10 @@ public class DiagramHandler {
 		return drawpanel;
 	}
 
+    public boolean isFileSaved(){
+        return fileHandler.isFileSaved();
+    }
+
 	public DiagramFileHandler getFileHandler() {
 		return fileHandler;
 	}

--- a/umlet-swing/src/main/java/com/baselet/diagram/io/DiagramFileHandler.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/io/DiagramFileHandler.java
@@ -112,6 +112,10 @@ public class DiagramFileHandler {
 		}
 	}
 
+    public boolean isFileSaved(){
+        return file != null;
+    }
+
 	public String getFileName() {
 		return fileName;
 	}


### PR DESCRIPTION
**This PR adds auto-save functionality as requested in issue #389.**

Whenever the application window loses focus, it will call the DiagramHandler#doSave method, unless the file has not been previously saved (e.g they have not actually saved it to a file already).

This feature is implemented primarily in the class **_SwingWindowListener**_, minus two methods added to **_DiagramHandler**_ and **_DiagramFileHandler**_. Those two methods are to check if the diagram has been saved previously.
