### PR TITLE
Add an "Export as" panel to the menu of UMLet standalone (Swing editi…

### DIFF
--- a/umlet-standalone/src/main/java/com/baselet/standalone/gui/MenuBuilder.java
+++ b/umlet-standalone/src/main/java/com/baselet/standalone/gui/MenuBuilder.java
@@ -3,6 +3,7 @@ package com.baselet.standalone.gui;
 import java.awt.event.KeyEvent;
 import java.util.Collection;
 
+import javax.swing.JButton;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
@@ -33,8 +34,9 @@ public class MenuBuilder {
 	private JMenu customNewFromTemplate;
 	private JMenuItem customEdit;
 	private JToggleButton mailButton;
+	private JButton exportAsButton;
 
-	public JMenuBar createMenu(JPanel searchPanel, JPanel zoomPanel, JToggleButton mailButton) {
+	public JMenuBar createMenu(JPanel searchPanel, JPanel zoomPanel, JPanel mailButtonPanel, JPanel exportAsPanel) {
 		/*********** CREATE MENU *****************/
 		JMenuBar menu = new JMenuBar();
 		menuFactory = MenuFactorySwing.getInstance();
@@ -109,8 +111,10 @@ public class MenuBuilder {
 
 		menu.add(searchPanel);
 		menu.add(zoomPanel);
-		this.mailButton = mailButton;
-		menu.add(mailButton);
+		menu.add(mailButtonPanel);
+		mailButton = (JToggleButton) mailButtonPanel.getComponent(0);
+		menu.add(exportAsPanel);
+		exportAsButton = (JButton) exportAsPanel.getComponent(2);
 
 		return menu;
 	}
@@ -169,9 +173,11 @@ public class MenuBuilder {
 
 			if (handler == null || handler.getDrawPanel().getGridElements().isEmpty()) {
 				mailButton.setEnabled(false);
+				exportAsButton.setEnabled(false);
 			}
 			else {
 				mailButton.setEnabled(true);
+				exportAsButton.setEnabled(true);
 			}
 		}
 

--- a/umlet-standalone/src/main/java/com/baselet/standalone/gui/StandaloneGUIBuilder.java
+++ b/umlet-standalone/src/main/java/com/baselet/standalone/gui/StandaloneGUIBuilder.java
@@ -9,11 +9,13 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Locale;
 
 import javax.imageio.ImageIO;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.DefaultComboBoxModel;
+import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -29,6 +31,7 @@ import com.baselet.control.config.Config;
 import com.baselet.control.constants.Constants;
 import com.baselet.control.enums.Program;
 import com.baselet.gui.BaseGUIBuilder;
+import com.baselet.gui.ExportAsHandler;
 import com.baselet.gui.filedrop.FileDrop;
 import com.baselet.gui.filedrop.FileDropListener;
 import com.baselet.gui.listener.GUIListener;
@@ -36,9 +39,11 @@ import com.baselet.gui.listener.UmletWindowFocusListener;
 
 public class StandaloneGUIBuilder extends BaseGUIBuilder {
 
+	private JComboBox exportAsComboBox;
 	private JComboBox zoomComboBox;
 	private ZoomListener zoomListener;
 
+	private JButton exportAsButton;
 	private JTextField searchField;
 	private JTabbedPane diagramtabs;
 	private JToggleButton mailButton;
@@ -60,8 +65,13 @@ public class StandaloneGUIBuilder extends BaseGUIBuilder {
 	}
 
 	public JFrame initSwingGui(MenuBuilder menuBuilder) {
+		JPanel exportAsPanel = createExportAsPanel();
+		ExportAsHandler.init(exportAsComboBox, exportAsButton);
+		setExportAsHandlerAsActionListener();
+
 		JFrame mainFrame = new JFrame();
 		mainFrame.addWindowFocusListener(new UmletWindowFocusListener());
+		mainFrame.addKeyListener(ExportAsHandler.getInstance());
 		mainFrame.addKeyListener(new GUIListener());
 		mainFrame.addKeyListener(new SearchKeyListener());
 		mainFrame.addWindowListener(new SwingWindowListener());
@@ -78,7 +88,7 @@ public class StandaloneGUIBuilder extends BaseGUIBuilder {
 			mainFrame.setVisible(true);
 		}
 
-		mainFrame.setJMenuBar(menuBuilder.createMenu(createSearchPanel(), createZoomPanel(), createMailButton()));
+		mainFrame.setJMenuBar(menuBuilder.createMenu(createSearchPanel(), createZoomPanel(), createMailButtonPanel(), exportAsPanel));
 
 		JPanel diagramTabPanel = createDiagramTabPanel();
 		int mainDividerLoc = Math.min(mainFrame.getSize().width - Constants.MIN_MAIN_SPLITPANEL_SIZE, Config.getInstance().getMain_split_position());
@@ -89,6 +99,55 @@ public class StandaloneGUIBuilder extends BaseGUIBuilder {
 		mainFrame.setVisible(true);
 
 		return mainFrame;
+	}
+
+	public JPanel createMailButtonPanel() {
+		createMailButton();
+
+		JPanel mailButtonPanel = new JPanel();
+		mailButtonPanel.setOpaque(false);
+		mailButtonPanel.setLayout(new BoxLayout(mailButtonPanel, BoxLayout.X_AXIS));
+		mailButtonPanel.add(mailButton);
+		mailButtonPanel.add(Box.createRigidArea(new Dimension(20, 0)));
+		return mailButtonPanel;
+	}
+
+	private void createExportAsComboBox() {
+		exportAsComboBox = new JComboBox();
+		exportAsComboBox.setPreferredSize(new Dimension(80, 24));
+		exportAsComboBox.setMinimumSize(exportAsComboBox.getPreferredSize());
+		exportAsComboBox.setMaximumSize(exportAsComboBox.getPreferredSize());
+		
+		String[] exportAsValues = new String[Constants.exportFormatList.size()];
+		for (int n = 0; n < exportAsValues.length; n++) {
+			String format = Constants.exportFormatList.get(n);
+			exportAsValues[n] = format.toUpperCase(Locale.ENGLISH);
+		}
+		
+		exportAsComboBox.setModel(new DefaultComboBoxModel(exportAsValues));
+		exportAsComboBox.setSelectedIndex(Constants.getIndexOfPdfExportFormat());
+	}
+
+	private void createExportAsButton(JComboBox exportAsComboBox) {
+		exportAsButton = new JButton("Export");
+		exportAsButton.setRequestFocusEnabled(false);
+	}
+
+	private void setExportAsHandlerAsActionListener() {
+		exportAsButton.addActionListener(ExportAsHandler.getInstance());
+	}
+
+	public JPanel createExportAsPanel() {
+		createExportAsComboBox();
+		createExportAsButton(exportAsComboBox);
+		
+		JPanel exportAsPanel = new JPanel();
+		exportAsPanel.setOpaque(false);
+		exportAsPanel.setLayout(new BoxLayout(exportAsPanel, BoxLayout.X_AXIS));
+		exportAsPanel.add(new JLabel("Export as:   "));
+		exportAsPanel.add(exportAsComboBox);
+		exportAsPanel.add(exportAsButton);
+		return exportAsPanel;
 	}
 
 	/**

--- a/umlet-standalone/src/main/java/com/baselet/standalone/gui/TabListener.java
+++ b/umlet-standalone/src/main/java/com/baselet/standalone/gui/TabListener.java
@@ -8,6 +8,7 @@ import javax.swing.JTabbedPane;
 import com.baselet.diagram.DiagramHandler;
 import com.baselet.gui.BaseGUI;
 import com.baselet.gui.CurrentGui;
+import com.baselet.gui.ExportAsHandler;
 
 public class TabListener implements MouseListener {
 
@@ -43,6 +44,8 @@ public class TabListener implements MouseListener {
 		if (gui != null) {
 			gui.setValueOfZoomDisplay(handler.getGridSize());
 		}
+
+		ExportAsHandler.getInstance().diagramTabIsActivated();
 	}
 
 	@Override

--- a/umlet-swing/src/main/java/com/baselet/control/Main.java
+++ b/umlet-swing/src/main/java/com/baselet/control/Main.java
@@ -11,6 +11,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 import javax.swing.filechooser.FileSystemView;
 
+import com.baselet.gui.ExportAsHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,12 +99,18 @@ public class Main implements CanCloseProgram, CanOpenDiagram {
 		if (diagrams.size() == 1) {
 			setPropertyPanelToGridElement(null);
 		}
+
+		ExportAsHandler.getInstance().newDiagramTab();
 	}
 
 	public void doOpenFromFileChooser() {
 		List<String> files = new OpenFileChooser().getFilesToOpen(CurrentGui.getInstance().getGui().getMainFrame());
 		for (String file : files) {
 			doOpen(file);
+		}
+
+		if (!files.isEmpty()) {
+			ExportAsHandler.getInstance().newDiagramTab();
 		}
 	}
 

--- a/umlet-swing/src/main/java/com/baselet/control/constants/Constants.java
+++ b/umlet-swing/src/main/java/com/baselet/control/constants/Constants.java
@@ -61,6 +61,14 @@ public abstract class Constants extends SharedConstants {
 	/**** EXPORT FORMATS ****/
 	public static final List<String> exportFormatList = Arrays.asList(new String[] { "bmp", "eps", "gif", "jpg", "pdf", "png", "svg" });
 
+	public static final int getIndexOfExportFormat(String formatExtension) {
+		return exportFormatList.indexOf(formatExtension);
+	}
+
+	public static final int getIndexOfPdfExportFormat() {
+		return getIndexOfExportFormat("pdf");
+	}
+
 	/**** ZOOM VALUES ****/
 	public static final ArrayList<String> zoomValueList = new ArrayList<String>();
 

--- a/umlet-swing/src/main/java/com/baselet/diagram/DiagramHandler.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/DiagramHandler.java
@@ -30,6 +30,7 @@ import com.baselet.element.old.custom.CustomElement;
 import com.baselet.element.old.element.Relation;
 import com.baselet.gui.BaseGUI;
 import com.baselet.gui.CurrentGui;
+import com.baselet.gui.ExportAsHandler;
 import com.baselet.gui.command.Controller;
 import com.baselet.gui.listener.DiagramListener;
 import com.baselet.gui.listener.GridElementListener;
@@ -163,18 +164,21 @@ public class DiagramHandler {
 		}
 	}
 
-	public void doSaveAs(String extension) {
+	public boolean doSaveAs(String extension) {
 		if (drawpanel.getGridElements().isEmpty()) {
 			displayError(ErrorMessages.ERROR_SAVING_EMPTY_DIAGRAM);
+			return false;
 		}
 		else {
 			try {
-				fileHandler.doSaveAs(extension);
+				boolean diagramSaved = fileHandler.doSaveAs(extension);
 				reloadPalettes();
 				CurrentGui.getInstance().getGui().afterSaving();
+				return diagramSaved;
 			} catch (IOException e) {
 				log.error(ErrorMessages.ERROR_SAVING_FILE, e);
 				displayError(ErrorMessages.ERROR_SAVING_FILE + e.getMessage());
+				return false;
 			}
 		}
 	}
@@ -211,6 +215,7 @@ public class DiagramHandler {
 
 	public void doClose() {
 		if (askSaveIfDirty()) {
+			ExportAsHandler.getInstance().diagramTabIsClosed();
 			Main.getInstance().getDiagrams().remove(this); // remove this DiagramHandler from the list of managed diagrams
 			drawpanel.getSelector().deselectAll(); // deselect all elements of the drawpanel (must be done BEFORE closing the tab, because otherwise it resets this DrawHandler again as the current DrawHandler
 			CurrentGui.getInstance().getGui().close(this); // close the GUI (tab, ...) and set the next active tab as the CurrentDiagram

--- a/umlet-swing/src/main/java/com/baselet/diagram/io/DiagramFileHandler.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/io/DiagramFileHandler.java
@@ -130,6 +130,10 @@ public class DiagramFileHandler {
 		CurrentGui.getInstance().getGui().updateDiagramName(handler, handler.getName());
 	}
 
+	public String getLastExportFilePath() {
+		return lastExportFile != null ? lastExportFile.getAbsolutePath() : "";
+	}
+
 	private void createXMLOutputDoc(Document doc, Collection<GridElement> elements, Element current) {
 		for (GridElement e : elements) {
 			appendRecursively(doc, current, e);
@@ -265,13 +269,13 @@ public class DiagramFileHandler {
 		}
 	}
 
-	public void doSaveAs(String fileextension) throws IOException {
+	public boolean doSaveAs(String fileextension) throws IOException {
 		boolean ownXmlFormat = fileextension.equals(Program.getInstance().getExtension());
 		JFileChooser fileChooser = createSaveFileChooser(!ownXmlFormat);
 		String fileName = chooseFileName(ownXmlFormat, filters.get(fileextension), fileChooser);
 		String extension = fileextensions.get(fileChooser.getFileFilter());
 		if (fileName == null) {
-			return; // If the filechooser has been closed without saving
+			return false; // If the filechooser has been closed without saving
 		}
 		if (!fileName.endsWith("." + extension)) {
 			fileName += "." + extension;
@@ -288,6 +292,8 @@ public class DiagramFileHandler {
 			lastExportFile = fileToSave;
 			doExportAs(extension, fileToSave);
 		}
+
+		return true;
 	}
 
 	public File doSaveTempDiagram(String filename, String fileextension) throws IOException {

--- a/umlet-swing/src/main/java/com/baselet/gui/ExportAsHandler.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/ExportAsHandler.java
@@ -1,0 +1,199 @@
+package com.baselet.gui;
+
+import com.baselet.control.ErrorMessages;
+import com.baselet.control.constants.Constants;
+import com.baselet.diagram.CurrentDiagram;
+import com.baselet.diagram.DiagramHandler;
+import com.baselet.diagram.Notifier;
+import com.baselet.diagram.io.DiagramFileHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.JComboBox;
+import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ExportAsHandler implements KeyListener, ActionListener {
+	private JComboBox exportAsComboBox;
+	private JButton exportAsButton;
+	private Map<DiagramHandler, String> lastExportedFilePathsPerTab = new HashMap<DiagramHandler, String>();
+
+	private static final Logger log = LoggerFactory.getLogger(ExportAsHandler.class);
+
+	private static ExportAsHandler instance;
+
+	public static ExportAsHandler getInstance() {
+		if (instance == null) {
+			throw new RuntimeException("You need to call init() first");
+		}
+		return instance;
+	}
+
+	public static void init(JComboBox exportAsComboxBox, JButton exportAsButton) {
+		if (instance == null) {
+			instance = new ExportAsHandler(exportAsComboxBox, exportAsButton);
+		}
+	}
+
+	private ExportAsHandler(JComboBox exportAsComboxBox, JButton exportAsButton) {
+		this.exportAsComboBox = exportAsComboxBox;
+		this.exportAsButton = exportAsButton;
+	}
+
+	@Override
+	public void keyPressed(KeyEvent e) {
+		if (!exportAsButton.isEnabled()) {
+			return;
+		}
+
+		boolean ctrl_e_pressed = e.isControlDown() && e.getKeyCode() == KeyEvent.VK_E;
+		if (ctrl_e_pressed) {
+			exportAs();
+		}
+	}
+
+	@Override
+	public void actionPerformed(ActionEvent e) {
+		exportAs();
+	}
+
+	public void fileExportViaMenu(String exportedFilePath) {
+		setExportedFilePath(exportedFilePath);
+
+		String fileExtension = filePathExtension(exportedFilePath);
+		selectExportFormat(fileExtension);
+	}
+
+	public void newDiagramTab() {
+		selectPdfAsExportFormat();
+	}
+
+	public void diagramTabIsActivated() {
+		if (noExportForCurrentDiagramYet()) {
+			selectPdfAsExportFormat();
+		} else {
+			String lastExportFormat = filePathExtension(lastExportedFilePathsPerTab.get(currentDiagramHandler()));
+			selectExportFormat(lastExportFormat);
+		}
+	}
+
+	public void diagramTabIsClosed() {
+		lastExportedFilePathsPerTab.remove(currentDiagramHandler());
+	}
+
+	private String getSelectedExportFileExtension() {
+		return exportAsComboBox.getSelectedItem().toString().toLowerCase();
+	}
+
+	private void selectExportFormat(String formatExtension) {
+		int extensionIndex = Constants.getIndexOfExportFormat(formatExtension);
+		if (extensionIndex > -1) {
+			exportAsComboBox.setSelectedIndex(extensionIndex);
+		}
+	}
+
+	private void selectPdfAsExportFormat() {
+		int extensionIndex = Constants.getIndexOfPdfExportFormat();
+		if (extensionIndex > -1) {
+			exportAsComboBox.setSelectedIndex(extensionIndex);
+		}
+	}
+
+	private String exportWithSaveDialog(String exportExtension) {
+		boolean successfullySaved = currentDiagramHandler().doSaveAs(exportExtension);
+
+		if (successfullySaved) {
+			return currentDiagramHandler().getFileHandler().getLastExportFilePath();
+		} else {
+			return null;
+		}
+	}
+
+	private String exportQuietly(String exportExtension) {
+		DiagramFileHandler currentFileHandler = currentDiagramHandler().getFileHandler();
+		String lastExportFilePath = currentFileHandler.getLastExportFilePath();
+		File exportFile = new File(lastExportFilePath);
+
+		try {
+			currentFileHandler.doExportAs(exportExtension, exportFile);
+			return exportFile.getAbsolutePath();
+		} catch (IOException e) {
+			log.error(ErrorMessages.ERROR_SAVING_FILE, e);
+			displayError(ErrorMessages.ERROR_SAVING_FILE + e.getMessage());
+			return null;
+		}
+	}
+
+	private boolean noExportForCurrentDiagramYet() {
+		return !lastExportedFilePathsPerTab.containsKey(currentDiagramHandler());
+	}
+
+	private boolean exportExtensionHasChanged(String exportExtension) {
+		if (noExportForCurrentDiagramYet()) {
+			return false;
+		}
+
+		String exportedFilePath = lastExportedFilePathsPerTab.get(currentDiagramHandler());
+		String exportedFileExtension = filePathExtension(exportedFilePath);
+		return !exportExtension.equals(exportedFileExtension);
+	}
+
+	private void setExportedFilePath(String exportedFilePath) {
+		lastExportedFilePathsPerTab.put(currentDiagramHandler(), exportedFilePath);
+	}
+
+	private DiagramHandler currentDiagramHandler() {
+		return CurrentDiagram.getInstance().getDiagramHandler();
+	}
+
+	private void exportAs() {
+		String exportExtension = getSelectedExportFileExtension();
+
+		String exportedFilePath;
+		if (noExportForCurrentDiagramYet() || exportExtensionHasChanged(exportExtension)) {
+			exportedFilePath = exportWithSaveDialog(exportExtension);
+		} else {
+			exportedFilePath = exportQuietly(exportExtension);
+		}
+
+		if (exportedFilePath != null && !exportedFilePath.isEmpty()) {
+			setExportedFilePath(exportedFilePath);
+			Notifier.getInstance().showInfo("Diagram exported to " + exportedFilePath);
+		}
+	}
+
+	private String filePathExtension(String filePath) {
+		if (filePath == null) {
+			return null;
+		}
+
+		int extensionPos = filePath.indexOf(".");
+		if (extensionPos > 0) {
+			return filePath.substring(extensionPos + 1);
+		} else {
+			return filePath;
+		}
+	}
+
+	private void displayError(String error) {
+		JOptionPane.showMessageDialog(CurrentGui.getInstance().getGui().getMainFrame(), error, "ERROR", JOptionPane.ERROR_MESSAGE);
+	}
+
+	@Override
+	public void keyTyped(KeyEvent e) {
+		// NOOP
+	}
+
+	@Override
+	public void keyReleased(KeyEvent e) {
+		// NOOP
+	}
+}

--- a/umlet-swing/src/main/java/com/baselet/gui/menu/MenuFactory.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/menu/MenuFactory.java
@@ -64,6 +64,7 @@ import com.baselet.generator.ClassDiagramConverter;
 import com.baselet.gui.BaseGUI;
 import com.baselet.gui.BrowserLauncher;
 import com.baselet.gui.CurrentGui;
+import com.baselet.gui.ExportAsHandler;
 import com.baselet.gui.OptionPanel;
 import com.baselet.gui.command.Align;
 import com.baselet.gui.command.ChangeElementSetting;
@@ -110,7 +111,11 @@ public class MenuFactory {
 					diagramHandler.doSaveAs(Program.getInstance().getExtension());
 				}
 				else if (menuItem.equals(EXPORT_AS) && diagramHandler != null) {
-					diagramHandler.doSaveAs((String) param);
+					boolean diagramExported = diagramHandler.doSaveAs((String) param);
+					if (diagramExported) {
+						String lastExportFilePath = CurrentDiagram.getInstance().getDiagramHandler().getFileHandler().getLastExportFilePath();
+						ExportAsHandler.getInstance().fileExportViaMenu(lastExportFilePath);
+					}
 				}
 				else if (menuItem.equals(MAIL_TO)) {
 					gui.setMailPanelEnabled(!gui.isMailPanelVisible());


### PR DESCRIPTION
…on) for quick export of the current diagram

The changes in this commit extend the menu bar with an "Export as" panel that
comprises a combobox with the export formats supported by UMLet, i.e., the same
file formats available at the File menu in its "Export as..." entry. Furthermore,
the new panel also contains an "Export" button. Next to clicking it, the button
may also be activated by hitting Ctrl+E.

The "Export" button behaves slightly different depending on the current diagram
tab's "export status":
  1. If the diagram has not been exported before, a file chooser for the export
     destination is openened. That is, the button behaves exactly like the
     file format entries under the "Export as..." submenu.
  2. If the diagram has been exported the button's behavior depends on the
     following circumstances:
       2.1 The user did not change the export format extension in the combo
           box and did not export the diagram leveraging the "Export as..."
           submenu: The diagram gets directly exported to the destination it
           was exported the last time. Note, that there is no warning in case
           the previously exported file exists, i.e., it may be overwritten
           without any warning.
       2.2 The user changed the export format extension or exported the diagram
           via the menu, whereby she changed the name of the export file: The
           button behaves like the file format entries under the "Export as..."
           submenu (same behavior as described above in 1.).

When the user opens a new tab, either by clicking an "File" --> "New" or by
opening a bunch of files via "File" --> "Open...", the format in the combo box
will be set to "PDF", which is the default export format. In contrast, if a
user switches from one diagram tab to another and the diagram has been exported
before, the combo box will be set to the file format of the last export file.