### PR TITLE
Typo in sh script

### DIFF
--- a/umlet-standalone/src/exe/umlet.sh
+++ b/umlet-standalone/src/exe/umlet.sh
@@ -28,7 +28,7 @@ if [ ! -z "${programDir}" ] ; then
 fi
 
 # UMLET_HOME wins against deprecated programDir
-if [ ! -x "${UMLET_HOME}" ] ; then
+if [ ! -z "${UMLET_HOME}" ] ; then
   _UMLET_HOME="${UMLET_HOME}"
 fi
 


### PR DESCRIPTION
Wrong test switch. Didn't think ${UMLET_HOME} should be tested if it is  executable. Pre-fix breaks default application start.