### PR TITLE
Parameter to open diagram on load (umletino)

### DIFF
--- a/umlet-gwt/src/main/java/com/baselet/gwt/client/view/MainView.java
+++ b/umlet-gwt/src/main/java/com/baselet/gwt/client/view/MainView.java
@@ -1,5 +1,8 @@
 package com.baselet.gwt.client.view;
 
+import com.baselet.gwt.client.view.utils.OnLoad;
+import com.google.gwt.event.shared.GwtEvent;
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.vectomatic.file.FileUploadExt;
@@ -49,6 +52,9 @@ import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.SimpleLayoutPanel;
 import com.google.gwt.user.client.ui.SplitLayoutPanel;
 import com.google.gwt.user.client.ui.Widget;
+
+import java.io.IOException;
+import java.net.URL;
 
 public class MainView extends Composite {
 
@@ -213,6 +219,11 @@ public class MainView extends Composite {
 		dropboxInt = new DropboxIntegration(diagramPanel);
 		dropboxInt.exposeDropboxImportJSCallback(dropboxInt);
 		dropboxInt.exposeDropboxShowNotification(dropboxInt);
+
+		String uxfStartup = Window.Location.getParameter("uxfOnLoad");
+		if (uxfStartup != null) {
+			OnLoad.OnLoad(uxfStartup, diagramPanel);
+		}
 	}
 
 	private void addRestoreMenuItem(final String chosenName) {

--- a/umlet-gwt/src/main/java/com/baselet/gwt/client/view/utils/OnLoad.java
+++ b/umlet-gwt/src/main/java/com/baselet/gwt/client/view/utils/OnLoad.java
@@ -1,0 +1,48 @@
+package com.baselet.gwt.client.view.utils;
+
+import com.baselet.gwt.client.base.Notification;
+import com.baselet.gwt.client.element.DiagramXmlParser;
+import com.baselet.gwt.client.view.DrawPanel;
+import com.google.gwt.http.client.*;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.SplitLayoutPanel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OnLoad {
+
+  private final Logger log = LoggerFactory.getLogger(OnLoad.class);
+
+  public static void OnLoad(String url, DrawPanel diagramPanel) {
+
+    RequestBuilder builder = new RequestBuilder(RequestBuilder.GET, url);
+    try {
+      builder.sendRequest(null, new RequestCallback() {
+
+        @Override
+        public void onError(Request request, Throwable exception) {
+          if (exception instanceof RequestTimeoutException) {
+            Window.alert("The request has timed out");
+          }
+          else {
+            Window.alert(exception.getMessage());
+          }
+        }
+
+        @Override
+        public void onResponseReceived(Request request, Response response) {
+          int STATUS_CODE_OK = 200;
+          if (STATUS_CODE_OK == response.getStatusCode()) {
+            diagramPanel.setDiagram(DiagramXmlParser.xmlToDiagram(response.getText()));
+          }
+          else {
+            Window.alert("Something went wrong: HTTP Status Code: " + response.getStatusCode());
+          }
+
+        }
+      });
+    } catch (RequestException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
Proposal for a small change that can improve diagram sharing experience a lot.
I store many diagrams on gist and when I need to share it with a colleague it requires explanation (download diagram from gist, open umletino, load diagram).

With this simple parameter I just have to share a link: i.e. http://www.umletino.com/umletino.html?uxfOnLoad=https://gist.githubusercontent.com/afdia/8f9c82c330c30f4c68b3357e6cf3d46f/raw/a923bf741f6041d99cf7311411b424de745396f3/errors%2520all%2520in%2520one%2520sequence

Maybe we can add another param to start in presentation mode (collapsing menu and palette panel and centering the diagram) and some kind of notification while diagram is loading.

![This](https://user-images.githubusercontent.com/415742/77164232-1f4ab700-6ab0-11ea-9635-d75153a86e0b.png) 

vs

![this](https://user-images.githubusercontent.com/415742/77164245-240f6b00-6ab0-11ea-939f-7420b8a371aa.png)

