### PR TITLE
Fix syntax caret reset to zero, by diagram save(using ctrl+s) 

### DIFF
--- a/umlet-swing/src/main/java/com/baselet/gui/pane/OwnSyntaxPane.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/pane/OwnSyntaxPane.java
@@ -157,6 +157,7 @@ public class OwnSyntaxPane {
 	private void setText(String text) {
 		if (!textArea.getText().equals(text)) {
 			textArea.setText(text); // Always set text even if they are equal to trigger correct syntax highlighting (if words to highlight have changed but text not)
+                        textArea.setCaretPosition(0);
 		}
 		
 		createHightLightMap();

--- a/umlet-swing/src/main/java/com/baselet/gui/pane/OwnSyntaxPane.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/pane/OwnSyntaxPane.java
@@ -158,7 +158,7 @@ public class OwnSyntaxPane {
 		if (!textArea.getText().equals(text)) {
 			textArea.setText(text); // Always set text even if they are equal to trigger correct syntax highlighting (if words to highlight have changed but text not)
 		}
-		textArea.setCaretPosition(0);
+		
 		createHightLightMap();
 		createAutocompletionCompletionProvider();
 	}


### PR DESCRIPTION
Related to issue #594 

Fix:  
Saving the diagram using `ctrl+S` won't reset the caret to the beginning, but changing elements in diagram will.

Commit note:  

Majors:  
* Syntax pane(`OwnSyntaxPane`) now won't reset the caret to position/index 0(at beginning)