### PR TITLE
Using String for group value 

### DIFF
--- a/umlet-elements/src/main/java/com/baselet/element/NewGridElement.java
+++ b/umlet-elements/src/main/java/com/baselet/element/NewGridElement.java
@@ -352,7 +352,7 @@ public abstract class NewGridElement implements GridElement {
 	}
 
 	@Override
-	public Integer getGroup() {
+	public String getGroup() {
 		return state.getFacetResponse(GroupFacet.class, null);
 	}
 

--- a/umlet-elements/src/main/java/com/baselet/element/Selector.java
+++ b/umlet-elements/src/main/java/com/baselet/element/Selector.java
@@ -45,12 +45,14 @@ public abstract class Selector {
 	}
 
 	private List<GridElement> expand(Collection<GridElement> elements) {
-		Map<Integer, Collection<GridElement>> map = Selector.createGroupElementMap(getAllElements());
+		Map<String, Collection<GridElement>> map = Selector.createGroupElementMap(getAllElements());
 		List<GridElement> elemenentsWithGroups = new ArrayList<GridElement>();
 		// add grouped elements BEFORE the really selected elements, to make sure the last element stays the same (because its content will be shown in the property panel)
+                String groupValue;
 		for (GridElement e : elements) {
-			if (e.getGroup() != null) {
-				Collection<GridElement> set = map.get(e.getGroup());
+                    groupValue = GroupFacet.getElementGroupValSafe(e.getGroup());
+			if (groupValue != null) {
+				Collection<GridElement> set = map.get(groupValue);
 				if (set != null) { // TODO set can be null in standalone version because getAllElements is empty (eg if grouped elements are selected when diagram is closed)
 					for (GridElement g : set) {
 						if (g != e) {
@@ -126,17 +128,17 @@ public abstract class Selector {
 		elements.add(element);
 	}
 
-	public Integer getUnusedGroup() {
+	public String getUnusedGroup() {
 		return getUnusedGroupId(createGroupElementMap(getAllElements()).keySet());
 	}
 
 	public abstract List<GridElement> getAllElements();
 
 	public static void replaceGroupsWithNewGroups(Collection<GridElement> elements, Selector selector) {
-		Set<Integer> usedIds = new HashSet<Integer>(createGroupElementMap(selector.getAllElements()).keySet());
-		Map<Integer, Collection<GridElement>> groupedElements = createGroupElementMap(elements);
-		for (Entry<Integer, Collection<GridElement>> entry : groupedElements.entrySet()) {
-			Integer unusedId = getUnusedGroupId(usedIds);
+		Set<String> usedIds = new HashSet<String>(createGroupElementMap(selector.getAllElements()).keySet());
+		Map<String, Collection<GridElement>> groupedElements = createGroupElementMap(elements);
+		for (Entry<String, Collection<GridElement>> entry : groupedElements.entrySet()) {
+			String unusedId = getUnusedGroupId(usedIds);
 			usedIds.add(unusedId);
 			for (GridElement e : entry.getValue()) {
 				e.setProperty(GroupFacet.KEY, unusedId);
@@ -144,29 +146,33 @@ public abstract class Selector {
 		}
 	}
 
-	public static Integer getUnusedGroupId(Collection<Integer> usedGroups) {
-		Integer newGroup;
-		if (usedGroups.isEmpty()) {
-			newGroup = 1;
-		}
-		else {
-			newGroup = Collections.max(usedGroups) + 1;
-		}
+	public static String getUnusedGroupId(Collection<String> usedGroups) {
+		String newGroup;
+                while(true){
+                    newGroup=GroupFacet.nextDefaultKey();
+                    if(usedGroups.contains(newGroup)==false){
+                        break;
+                    }
+                }
 		return newGroup;
 	}
 
-	public static Map<Integer, Collection<GridElement>> createGroupElementMap(Collection<GridElement> elements) {
-		Map<Integer, Collection<GridElement>> returnmap = new HashMap<Integer, Collection<GridElement>>();
+	public static Map<String, Collection<GridElement>> createGroupElementMap(Collection<GridElement> elements) {
+		Map<String, Collection<GridElement>> returnmap = new HashMap<String, Collection<GridElement>>();
+                String groupValue; 
 		for (GridElement e : elements) {
-			if (e.getGroup() != null) {
-				Collection<GridElement> elementsWithGroup = returnmap.get(e.getGroup());
+                    groupValue = GroupFacet.getElementGroupValSafe(e.getGroup());
+			if (groupValue != null) {
+				Collection<GridElement> elementsWithGroup = returnmap.get(groupValue);
 				if (elementsWithGroup == null) {
 					elementsWithGroup = new ArrayList<GridElement>();
-					returnmap.put(e.getGroup(), elementsWithGroup);
+					returnmap.put(groupValue, elementsWithGroup);
 				}
 				elementsWithGroup.add(e);
 			}
 		}
 		return returnmap;
 	}
+        
+        
 }

--- a/umlet-elements/src/main/java/com/baselet/element/facet/common/GroupFacet.java
+++ b/umlet-elements/src/main/java/com/baselet/element/facet/common/GroupFacet.java
@@ -3,26 +3,52 @@ package com.baselet.element.facet.common;
 import com.baselet.diagram.draw.helper.StyleException;
 import com.baselet.element.facet.FirstRunKeyValueFacet;
 import com.baselet.element.facet.PropertiesParserState;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class GroupFacet extends FirstRunKeyValueFacet {
 
-	public static final GroupFacet INSTANCE = new GroupFacet();
+   public static final GroupFacet INSTANCE = new GroupFacet();
 
-	private GroupFacet() {}
+    private GroupFacet() {}
 
-	public static final String KEY = "group";
+    public static final String KEY = "group";
+    public static final String VALUE_PREFIX = "group";
+    private static final int KEY_START_VAL = 0;
+    public static final AtomicInteger LAST_KNOWN_VAl = new AtomicInteger(KEY_START_VAL);
 
-	@Override
-	public KeyValue getKeyValue() {
-		return new KeyValue(KEY, false, "1", "grouped elements are selected at once");
-	}
+    public static final String nextDefaultKey() {
+        return String.format("%s-%d", VALUE_PREFIX, LAST_KNOWN_VAl.getAndIncrement());
+    }
 
-	@Override
-	public void handleValue(String value, PropertiesParserState state) {
-		try {
-			state.setFacetResponse(GroupFacet.class, Integer.valueOf(value));
-		} catch (NumberFormatException e) {
-			throw new StyleException("value must be a positive or negative integer");
-		}
-	}
+    @Override
+    public KeyValue getKeyValue() {
+        return new KeyValue(KEY, false, String.format("%s-%d", VALUE_PREFIX, KEY_START_VAL), "grouped elements are selected at once");
+    }
+
+    /**
+     * trimming the group value, returns null when val is not valid
+     */
+    public static String getElementGroupValSafe(String arg_group) {
+        if (arg_group == null || arg_group.length()==0) {
+            return null;
+        }
+        String _res = arg_group.trim();
+        if (_res.length() == 0) {
+            return null;
+        }
+        return _res;
+    }
+
+    @Override
+    public void handleValue(String value, PropertiesParserState state) {
+        String safeValue = getElementGroupValSafe(value);
+        if(safeValue==null || !value.equals(safeValue)){
+            if(value.length()>0){
+                throw new StyleException("Group value cannot have lead-tail whitespaces");
+            }else{
+                throw new StyleException("Group value cannot be empty");
+            }
+        }
+        state.setFacetResponse(GroupFacet.class, value);
+    }
 }

--- a/umlet-elements/src/main/java/com/baselet/element/interfaces/GridElement.java
+++ b/umlet-elements/src/main/java/com/baselet/element/interfaces/GridElement.java
@@ -16,7 +16,7 @@ public interface GridElement extends HasPanelAttributes {
 
 	void setRectangle(Rectangle bounds);
 
-	Integer getGroup();
+        String getGroup();
 
 	void setLocationDifference(int diffx, int diffy);
 

--- a/umlet-standalone/src/main/java/com/baselet/standalone/gui/MenuBuilder.java
+++ b/umlet-standalone/src/main/java/com/baselet/standalone/gui/MenuBuilder.java
@@ -13,6 +13,7 @@ import com.baselet.control.constants.MenuConstants;
 import com.baselet.diagram.CustomPreviewHandler;
 import com.baselet.diagram.DiagramHandler;
 import com.baselet.diagram.PaletteHandler;
+import com.baselet.element.facet.common.GroupFacet;
 import com.baselet.element.interfaces.GridElement;
 import com.baselet.gui.menu.MenuFactorySwing;
 
@@ -129,7 +130,7 @@ public class MenuBuilder {
 
 			boolean allElementsInGroup = true;
 			for (GridElement e : selectedElements) {
-				if (e.getGroup() == null) {
+				if ( GroupFacet.getElementGroupValSafe(e.getGroup()) == null) {
 					allElementsInGroup = false;
 				}
 			}

--- a/umlet-swing/src/main/java/com/baselet/element/old/OldGridElement.java
+++ b/umlet-swing/src/main/java/com/baselet/element/old/OldGridElement.java
@@ -440,11 +440,8 @@ public abstract class OldGridElement extends JComponent implements GridElement, 
 	}
 
 	@Override
-	public Integer getGroup() {
-		try {
-			return Integer.valueOf(getSettingHelper(GroupFacet.KEY, null));
-		} catch (NumberFormatException e) {/* default value applies */}
-		return null;
+	public String getGroup() {
+            return getSettingHelper(GroupFacet.KEY, null);
 	}
 
 	@Override

--- a/umlet-swing/src/main/java/com/baselet/gui/BaseGUI.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/BaseGUI.java
@@ -21,6 +21,7 @@ import com.baselet.control.config.Config;
 import com.baselet.diagram.CustomPreviewHandler;
 import com.baselet.diagram.DiagramHandler;
 import com.baselet.diagram.DrawPanel;
+import com.baselet.element.facet.common.GroupFacet;
 import com.baselet.element.interfaces.GridElement;
 import com.baselet.element.old.custom.CustomElement;
 import com.baselet.element.old.custom.CustomElementHandler;
@@ -76,7 +77,7 @@ public abstract class BaseGUI {
 
 		JMenuItem ungroup = menuFactory.createUngroup();
 		contextMenu.add(ungroup);
-		if (e.getGroup() == null) {
+		if ( GroupFacet.getElementGroupValSafe(e.getGroup()) == null) {
 			ungroup.setEnabled(false);
 		}
 

--- a/umlet-swing/src/main/java/com/baselet/gui/pane/OwnSyntaxPane.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/pane/OwnSyntaxPane.java
@@ -157,6 +157,7 @@ public class OwnSyntaxPane {
 	private void setText(String text) {
 		if (!textArea.getText().equals(text)) {
 			textArea.setText(text); // Always set text even if they are equal to trigger correct syntax highlighting (if words to highlight have changed but text not)
+                        textArea.setCaretPosition(0);
 		}
 		
 		createHightLightMap();

--- a/umlet-swing/src/main/java/com/baselet/gui/pane/OwnSyntaxPane.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/pane/OwnSyntaxPane.java
@@ -158,7 +158,7 @@ public class OwnSyntaxPane {
 		if (!textArea.getText().equals(text)) {
 			textArea.setText(text); // Always set text even if they are equal to trigger correct syntax highlighting (if words to highlight have changed but text not)
 		}
-		textArea.setCaretPosition(0);
+		
 		createHightLightMap();
 		createAutocompletionCompletionProvider();
 	}


### PR DESCRIPTION
Related to #580

Allowing String value, over integer for element's group value

Changes:
* new group value could be any string literal now, not just integers
* value must not start with lead/tail whitespace, e.g. `  db` / `entity ` are not allowed, however `" good group "` is allowed.
* empty values are not allowed (either zero len, or all whitespace)

Disclaimer: I didn't spend too much on testing, please contribute in test cases, thanks.

related commit: [4a6b3e6](https://github.com/911992/umlet/commit/242c35f25c0c2ff144773829818594bab78d0911)
