### PR TITLE
UW/UVC: Fixed border of context menu (again)

### DIFF
--- a/umlet-vscode/src/main/web/umletino.css
+++ b/umlet-vscode/src/main/web/umletino.css
@@ -132,7 +132,7 @@
     border-radius: 5px !important;
 }
 
-.gwt-PopupPanel {
+.gwt-PopupPanel.notificationPopup {
     border: 2px solid #bbb !important;
     border-radius: 5px !important;
     padding: 5px !important;

--- a/umlet-web/src/main/webapp/umletino.css
+++ b/umlet-web/src/main/webapp/umletino.css
@@ -149,7 +149,7 @@
     border-radius: 5px !important;
 }
 
-.gwt-PopupPanel {
+.gwt-PopupPanel.notificationPopup {
     border: 2px solid #bbb !important;
     border-radius: 5px !important;
     padding: 5px !important;


### PR DESCRIPTION
The zoom feature modified CSS files which reverted a context menu border width fix in dark mode. This PR fixes it again.