### PR TITLE
Support automatic UMLET_HOME discovery with umlet.sh via symlink

### DIFF
--- a/umlet-standalone/src/exe/umlet.sh
+++ b/umlet-standalone/src/exe/umlet.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # activate job monitoring
 # @see: http://www.linuxforums.org/forum/programming-scripting/139939-fg-no-job-control-script.html
 set -m
@@ -19,7 +19,7 @@ set -m
 # you must export the UMLET_HOME environment variable with the full qualified path of the UMLet installation directory.
 # export UMLET_HOME=/path/to/umlet
 
-_UMLET_HOME="$(cd $(dirname $0);pwd)"
+_UMLET_HOME="$(dirname $(readlink -f "${BASH_SOURCE[-1]}"))"
 
 # check and use programDir for backward compatibility
 if [ ! -z "${programDir}" ] ; then


### PR DESCRIPTION
Using readlink of $BASH_SOURCE instead of $0 provides a broader range
of autodiscovery of the true UMLET_HOME.

For example, if the user used a symlink:

ln -s ~/.umlet/umlet.sh ~/bin/umlet

Running umlet will then automatically find the umlet installation in
~/.umlet.

Requires bash.