### PR TITLE
Umlet unix wrapper: Allow to symlink the umtlet.sh

### DIFF
--- a/umlet-standalone/src/exe/umlet.sh
+++ b/umlet-standalone/src/exe/umlet.sh
@@ -19,7 +19,7 @@ set -m
 # you must export the UMLET_HOME environment variable with the full qualified path of the UMLet installation directory.
 # export UMLET_HOME=/path/to/umlet
 
-_UMLET_HOME="$(cd $(dirname $0);pwd)"
+_UMLET_HOME="$(dirname $(readlink -f $0))"
 
 # check and use programDir for backward compatibility
 if [ ! -z "${programDir}" ] ; then

--- a/umlet-standalone/src/exe/umlet.sh
+++ b/umlet-standalone/src/exe/umlet.sh
@@ -19,7 +19,7 @@ set -m
 # you must export the UMLET_HOME environment variable with the full qualified path of the UMLet installation directory.
 # export UMLET_HOME=/path/to/umlet
 
-_UMLET_HOME="$(dirname $(readlink -f $0))"
+_UMLET_HOME=$(dirname "$(readlink -f "$0")")
 
 # check and use programDir for backward compatibility
 if [ ! -z "${programDir}" ] ; then
@@ -56,7 +56,7 @@ _OS_NAME="$(uname -s)"
 case ${_OS_NAME} in
   'Darwin')
     _UMLET_JAVA_OPTS=" \
-      -Xdock:icon=${_UMLET_HOME}/img/umlet_logo.png \
+      -Xdock:icon="${_UMLET_HOME}/img/umlet_logo.png" \
       -Xdock:name=UMLet \
       ${_UMLET_JAVA_OPTS} \
       -Dapple.laf.useScreenMenuBar=true"
@@ -73,4 +73,4 @@ fi
 
 exec "${JAVA_CMD}" \
   ${_UMLET_JAVA_OPTS} \
-  -jar ${_UMLET_HOME}/umlet.jar ${_UMLET_OPTS}
+  -jar "${_UMLET_HOME}/umlet.jar" ${_UMLET_OPTS}


### PR DESCRIPTION
The default umlet.sh script is using a trick to resolve the default umlet path but this trick is not working well when using symbolic links. In this patch realink is used to resolve the path of the shell script instead of $0 directly

With this change in in place I was able to test that creating a symbolic link from a bin directory to the umlet.sh wrapper now works nicely but the old behaviour: adding umlet.sh into the path is also still functional.

Tested on Ubuntu 22.04 with UMLet version 15.1 2023-03-12