### PR TITLE
Add wrapper Logger interface

### DIFF
--- a/umlet-eclipse-plugin/META-INF/MANIFEST.MF
+++ b/umlet-eclipse-plugin/META-INF/MANIFEST.MF
@@ -5,12 +5,12 @@ Bundle-ManifestVersion: 2
 Bundle-Name: UMLet
 Bundle-SymbolicName: com.umlet.plugin;singleton:=true
 Bundle-Version: 15.2.0.qualifier
-Bundle-ClassPath: .,lib/umlet-swing.jar,lib/umlet-elements.jar,lib/slf
- 4j-api.jar,lib/autocomplete.jar,lib/batik-awt-util.jar,lib/batik-dom.
- jar,lib/batik-ext.jar,lib/batik-svggen.jar,lib/batik-util.jar,lib/bat
- ik-xml.jar,lib/commons-io.jar,lib/itextpdf.jar,lib/javaparser-core.ja
- r,lib/jlibeps.jar,lib/javax.mail.jar,lib/rsyntaxtextarea.jar,lib/ecj.
- jar,lib/bcel.jar,lib/rhino.jar,lib/slf4j-simple.jar
+Bundle-ClassPath: .,lib/bcel.jar,lib/batik-xml.jar,lib/rhino.jar,lib/j
+ avaparser-core.jar,lib/commons-io.jar,lib/batik-awt-util.jar,lib/itex
+ tpdf.jar,lib/javax.mail.jar,lib/batik-svggen.jar,lib/slf4j-api.jar,li
+ b/batik-dom.jar,lib/batik-util.jar,lib/batik-ext.jar,lib/rsyntaxtexta
+ rea.jar,lib/autocomplete.jar,lib/umlet-swing.jar,lib/jlibeps.jar,lib/
+ ecj.jar,lib/umlet-elements.jar,lib/slf4j-simple.jar
 Bundle-Activator: com.baselet.plugin.MainPlugin
 Export-Package: com.baselet.plugin,com.baselet.plugin.gui,com.baselet.
  plugin.wizard

--- a/umlet-eclipse-plugin/src/main/java/com/baselet/plugin/MainPlugin.java
+++ b/umlet-eclipse-plugin/src/main/java/com/baselet/plugin/MainPlugin.java
@@ -14,8 +14,8 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.Main;
 import com.baselet.control.config.handler.ConfigHandler;

--- a/umlet-eclipse-plugin/src/main/java/com/baselet/plugin/gui/EclipseGUI.java
+++ b/umlet-eclipse-plugin/src/main/java/com/baselet/plugin/gui/EclipseGUI.java
@@ -15,8 +15,8 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.swt.widgets.Display;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.CanCloseProgram;
 import com.baselet.control.config.Config;

--- a/umlet-eclipse-plugin/src/main/java/com/baselet/plugin/gui/Editor.java
+++ b/umlet-eclipse-plugin/src/main/java/com/baselet/plugin/gui/Editor.java
@@ -35,8 +35,8 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.internal.Workbench;
 import org.eclipse.ui.part.EditorPart;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.Main;
 import com.baselet.control.enums.Program;

--- a/umlet-eclipse-plugin/src/main/java/com/baselet/plugin/gui/MenuFactoryEclipse.java
+++ b/umlet-eclipse-plugin/src/main/java/com/baselet/plugin/gui/MenuFactoryEclipse.java
@@ -44,8 +44,8 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.Main;
 import com.baselet.control.constants.Constants;

--- a/umlet-eclipse-plugin/src/main/java/com/baselet/plugin/wizard/NewWizard.java
+++ b/umlet-eclipse-plugin/src/main/java/com/baselet/plugin/wizard/NewWizard.java
@@ -28,8 +28,8 @@ import org.eclipse.ui.IWorkbenchWizard;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.enums.Program;
 import com.baselet.plugin.MainPlugin;

--- a/umlet-elements/src/main/java/com/baselet/control/SharedUtils.java
+++ b/umlet-elements/src/main/java/com/baselet/control/SharedUtils.java
@@ -7,8 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.basics.geom.Rectangle;
 import com.baselet.control.constants.SharedConstants;

--- a/umlet-elements/src/main/java/com/baselet/control/basics/geom/Line.java
+++ b/umlet-elements/src/main/java/com/baselet/control/basics/geom/Line.java
@@ -2,8 +2,8 @@ package com.baselet.control.basics.geom;
 
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.enums.Direction;
 

--- a/umlet-elements/src/main/java/com/baselet/control/enums/Program.java
+++ b/umlet-elements/src/main/java/com/baselet/control/enums/Program.java
@@ -1,7 +1,7 @@
 package com.baselet.control.enums;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 /**
  * PROGRAM, PLATTFORM AND JAVA SPECIFIC SETTINGS

--- a/umlet-elements/src/main/java/com/baselet/diagram/draw/TextSplitter.java
+++ b/umlet-elements/src/main/java/com/baselet/diagram/draw/TextSplitter.java
@@ -8,8 +8,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.StringStyle;
 import com.baselet.control.enums.AlignHorizontal;

--- a/umlet-elements/src/main/java/com/baselet/diagram/draw/helper/ColorOwn.java
+++ b/umlet-elements/src/main/java/com/baselet/diagram/draw/helper/ColorOwn.java
@@ -1,7 +1,7 @@
 package com.baselet.diagram.draw.helper;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 public class ColorOwn {
 	private static final Logger log = LoggerFactory.getLogger(ColorOwn.class);

--- a/umlet-elements/src/main/java/com/baselet/element/NewGridElement.java
+++ b/umlet-elements/src/main/java/com/baselet/element/NewGridElement.java
@@ -9,8 +9,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.SharedUtils;
 import com.baselet.control.basics.geom.Dimension;

--- a/umlet-elements/src/main/java/com/baselet/element/UndoHistory.java
+++ b/umlet-elements/src/main/java/com/baselet/element/UndoHistory.java
@@ -3,8 +3,8 @@ package com.baselet.element;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 public class UndoHistory {
 

--- a/umlet-elements/src/main/java/com/baselet/element/elementnew/plot/PlotGrid.java
+++ b/umlet-elements/src/main/java/com/baselet/element/elementnew/plot/PlotGrid.java
@@ -3,8 +3,8 @@ package com.baselet.element.elementnew.plot;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.Matrix;
 import com.baselet.control.basics.geom.Dimension;

--- a/umlet-elements/src/main/java/com/baselet/element/elementnew/plot/parser/Parser.java
+++ b/umlet-elements/src/main/java/com/baselet/element/elementnew/plot/parser/Parser.java
@@ -7,8 +7,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map.Entry;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 public class Parser {
 

--- a/umlet-elements/src/main/java/com/baselet/element/facet/Facet.java
+++ b/umlet-elements/src/main/java/com/baselet/element/facet/Facet.java
@@ -2,8 +2,8 @@ package com.baselet.element.facet;
 
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.enums.Priority;
 import com.baselet.gui.AutocompletionText;

--- a/umlet-elements/src/main/java/com/baselet/element/facet/advancedelements/AdvancedDrawingsFacet.java
+++ b/umlet-elements/src/main/java/com/baselet/element/facet/advancedelements/AdvancedDrawingsFacet.java
@@ -3,8 +3,8 @@ package com.baselet.element.facet.advancedelements;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.enums.Priority;
 import com.baselet.element.facet.Facet;

--- a/umlet-elements/src/main/java/com/baselet/element/facet/customdrawings/CustomDrawingFacet.java
+++ b/umlet-elements/src/main/java/com/baselet/element/facet/customdrawings/CustomDrawingFacet.java
@@ -3,8 +3,8 @@ package com.baselet.element.facet.customdrawings;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.enums.FormatLabels;
 import com.baselet.control.enums.Priority;

--- a/umlet-elements/src/main/java/com/baselet/element/relation/facet/RelationLineTypeFacet.java
+++ b/umlet-elements/src/main/java/com/baselet/element/relation/facet/RelationLineTypeFacet.java
@@ -3,8 +3,8 @@ package com.baselet.element.relation.facet;
 import java.util.Arrays;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.SharedUtils;
 import com.baselet.control.basics.geom.Line;

--- a/umlet-elements/src/main/java/com/baselet/element/sequence_aio/facet/Lifeline.java
+++ b/umlet-elements/src/main/java/com/baselet/element/sequence_aio/facet/Lifeline.java
@@ -8,8 +8,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.basics.Line1D;
 import com.baselet.control.basics.geom.PointDouble;

--- a/umlet-elements/src/main/java/com/baselet/element/sequence_aio/facet/LostOrFoundMessage.java
+++ b/umlet-elements/src/main/java/com/baselet/element/sequence_aio/facet/LostOrFoundMessage.java
@@ -1,7 +1,7 @@
 package com.baselet.element.sequence_aio.facet;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.basics.Line1D;
 import com.baselet.control.basics.geom.Line;

--- a/umlet-elements/src/main/java/com/baselet/element/sequence_aio/facet/Message.java
+++ b/umlet-elements/src/main/java/com/baselet/element/sequence_aio/facet/Message.java
@@ -3,8 +3,8 @@ package com.baselet.element.sequence_aio.facet;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.basics.geom.Line;
 import com.baselet.control.basics.geom.PointDouble;

--- a/umlet-elements/src/main/java/com/baselet/element/sequence_aio/facet/SequenceDiagramBuilder.java
+++ b/umlet-elements/src/main/java/com/baselet/element/sequence_aio/facet/SequenceDiagramBuilder.java
@@ -7,8 +7,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.enums.LineType;
 import com.baselet.element.sequence_aio.facet.StateInvariant.StateInvariantStyle;

--- a/umlet-elements/src/main/java/com/baselet/element/sticking/Stickables.java
+++ b/umlet-elements/src/main/java/com/baselet/element/sticking/Stickables.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.basics.geom.PointDouble;
 import com.baselet.control.constants.SharedConstants;

--- a/umlet-elements/src/main/java/com/baselet/util/logging/LogLevel.java
+++ b/umlet-elements/src/main/java/com/baselet/util/logging/LogLevel.java
@@ -1,0 +1,9 @@
+package com.baselet.util.logging;
+
+public enum LogLevel {
+    TRACE,
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR
+}

--- a/umlet-elements/src/main/java/com/baselet/util/logging/Logger.java
+++ b/umlet-elements/src/main/java/com/baselet/util/logging/Logger.java
@@ -1,0 +1,18 @@
+package com.baselet.util.logging;
+
+
+public interface Logger {
+	void setLevel(LogLevel logLevel);
+	boolean isTraceEnabled();
+	LogLevel getLevel();
+	void trace(String msg);
+	void trace(String msg, Throwable throwable);
+	void debug(String msg);
+	void debug(String msg, Throwable throwable);
+	void info(String msg);
+	void info(String msg, Throwable throwable);
+	void warn(String msg);
+	void warn(String msg, Throwable throwable);
+	void error(String msg);
+	void error(String msg, Throwable throwable);
+}

--- a/umlet-elements/src/main/java/com/baselet/util/logging/LoggerFactory.java
+++ b/umlet-elements/src/main/java/com/baselet/util/logging/LoggerFactory.java
@@ -1,0 +1,13 @@
+package com.baselet.util.logging;
+
+import com.baselet.util.logging.impl.LoggerImpl;
+
+public class LoggerFactory {
+    public static Logger getLogger(Class clazz) {
+        return new LoggerImpl(clazz.getName());
+    }
+
+    public Logger getLogger(Class clazz, LogLevel logLevel) {
+        return new LoggerImpl(clazz.getName(), logLevel);
+    }
+}

--- a/umlet-elements/src/main/java/com/baselet/util/logging/impl/LoggerImpl.java
+++ b/umlet-elements/src/main/java/com/baselet/util/logging/impl/LoggerImpl.java
@@ -1,0 +1,110 @@
+package com.baselet.util.logging.impl;
+
+import com.baselet.util.logging.LogLevel;
+import com.baselet.util.logging.Logger;
+
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+
+public class LoggerImpl implements Logger {
+    private final String className;
+    private LogLevel logLevel;
+    private final java.util.logging.Logger logger;
+
+    public LoggerImpl(String className) {
+        this.className = className;
+        this.logLevel = LogLevel.INFO;
+        logger = java.util.logging.Logger.getLogger(this.className);
+        logger.setLevel(convertLogLevel(this.logLevel));
+    }
+
+    public LoggerImpl(String className, LogLevel logLevel) {
+        this.className = className;
+        this.logLevel = logLevel;
+        logger = java.util.logging.Logger.getLogger(this.className);
+        logger.setLevel(convertLogLevel(this.logLevel));
+    }
+
+    @Override
+    public void setLevel(LogLevel logLevel) {
+        this.logLevel = logLevel;
+        logger.setLevel(convertLogLevel(this.logLevel));
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return this.logLevel.equals(LogLevel.TRACE);
+    }
+
+    @Override
+    public LogLevel getLevel() {
+        return logLevel;
+    }
+
+    @Override
+    public void trace(String msg) {
+        logger.log(convertLogLevel(LogLevel.TRACE), msg);
+    }
+
+    @Override
+    public void trace(String msg, Throwable throwable) {
+        logger.log(convertLogLevel(LogLevel.TRACE), msg, throwable);
+    }
+
+    @Override
+    public void debug(String msg) {
+        logger.log(convertLogLevel(LogLevel.DEBUG), msg);
+    }
+
+    @Override
+    public void debug(String msg, Throwable throwable) {
+        logger.log(convertLogLevel(LogLevel.DEBUG), msg, throwable);
+    }
+
+    @Override
+    public void info(String msg) {
+        logger.log(convertLogLevel(LogLevel.INFO), msg);
+    }
+
+    @Override
+    public void info(String msg, Throwable throwable) {
+        logger.log(convertLogLevel(LogLevel.INFO), msg, throwable);
+    }
+
+    @Override
+    public void warn(String msg) {
+        logger.log(convertLogLevel(LogLevel.WARN), msg);
+    }
+
+    @Override
+    public void warn(String msg, Throwable throwable) {
+        logger.log(convertLogLevel(LogLevel.WARN), msg, throwable);
+    }
+
+    @Override
+    public void error(String msg) {
+        logger.log(convertLogLevel(LogLevel.ERROR), msg);
+    }
+
+    @Override
+    public void error(String msg, Throwable throwable) {
+        logger.log(convertLogLevel(LogLevel.ERROR), msg, throwable);
+    }
+
+    private Level convertLogLevel(LogLevel level) {
+        switch (level) {
+            case TRACE:
+                return Level.FINER;
+            case DEBUG:
+                return Level.FINE;
+            case INFO:
+                return Level.INFO;
+            case WARN:
+                return Level.WARNING;
+            case ERROR:
+                return Level.SEVERE;
+            default:
+                return Level.INFO;
+        }
+    }
+}

--- a/umlet-elements/src/main/javacc/CustomDrawingParser.jj
+++ b/umlet-elements/src/main/javacc/CustomDrawingParser.jj
@@ -11,7 +11,8 @@ options {
 PARSER_BEGIN(CustomDrawingParser)
 package com.baselet.element.facet.customdrawings.gen;
 
-import org.slf4j.Logger;import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.enums.AlignHorizontal;
 import com.baselet.control.enums.LineType;

--- a/umlet-elements/src/main/javacc/SequenceAllInOneParser.jj
+++ b/umlet-elements/src/main/javacc/SequenceAllInOneParser.jj
@@ -17,8 +17,8 @@ import com.baselet.element.sequence_aio.facet.Message.ArrowType;
 import com.baselet.element.sequence_aio.facet.SequenceDiagramBuilder;
 import com.baselet.element.sequence_aio.facet.SequenceDiagramException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 public class SequenceAllInOneParser {
 	private static final Logger log = LoggerFactory.getLogger(SequenceAllInOneParser.class);
@@ -66,7 +66,8 @@ public class SequenceAllInOneParser {
 
 	private class InteractionConstraint {
 		private String lifelineId = null;
-		private String text = "";	}
+		private String text = "";
+	}
 
 	private class LifelineInterval {
 		private String startId;
@@ -90,7 +91,8 @@ PARSER_END(SequenceAllInOneParser)
 }
 
 < DEFAULT > TOKEN:
-{	< DIAGRAM_OPTION_OVERRIDE_ID :"overrideIds=" >
+{
+	< DIAGRAM_OPTION_OVERRIDE_ID :"overrideIds=" >
 	| < DIAGRAM_OPTION_AUTO_TICK: "autoTick=" >
 	| < TRUE: "true" >
 	| < FALSE: "false" >
@@ -157,7 +159,8 @@ PARSER_END(SequenceAllInOneParser)
 	| < TICK: "tick=" >
 	| < COMBINED_FRAGMENT: "combinedFragment=" > : CF_OPERATOR
 	| < INTERACTION_CONSTRAINT: "constraint=" >
-	| < UNSIGNED_INT_CONSTANT: ( ["0" - "9"] ) + >	| < DEFAULT_NEW_LINE: "\n" | "\r\n" | "\r" >
+	| < UNSIGNED_INT_CONSTANT: ( ["0" - "9"] ) + >
+	| < DEFAULT_NEW_LINE: "\n" | "\r\n" | "\r" >
 }
 
 < LIFELINE_DEF, DEFAULT > TOKEN :
@@ -174,7 +177,8 @@ PARSER_END(SequenceAllInOneParser)
 }
 
 < CF_OPERATOR > TOKEN :
-{	< COMBINED_FRAGMENT_OPERATOR: /* since ; and ~ are special characters which delimit the operator they need to be escaped */
+{
+	< COMBINED_FRAGMENT_OPERATOR: /* since ; and ~ are special characters which delimit the operator they need to be escaped */
 		( 
 			~["~","\\","\n","\r",";"] 
 			| ("\\" ["\\","~","|","n",";"])
@@ -296,7 +300,8 @@ void LifelineDef(SequenceDiagramBuilder diagram) :
 	) *
 	{
 		if("lost".equals(id) || "found".equals(id)) {
-			throw new SequenceDiagramException("'lost' and 'found' are keywords and can not be used as lifeline identifiers.");		}
+			throw new SequenceDiagramException("'lost' and 'found' are keywords and can not be used as lifeline identifiers.");
+		}
 		diagram.addLiveline(name, id, headType, createdOnStart, execSpecFromStart);
 	}
 }
@@ -407,7 +412,8 @@ void CombinedFragment(SequenceDiagramBuilder diagram) :
 	| (
 		< T_DDOT > (< T_EQ > id=LifelineId())?
 		{ diagram.endAndBeginOperand(id); }
-	)}
+	)
+}
 
 void Message(SequenceDiagramBuilder diagram) :
 {
@@ -465,16 +471,19 @@ void Message(SequenceDiagramBuilder diagram) :
 				throw new SequenceDiagramException("Error: a messages with a gate can only have a duration of 0, but the duration was " + duration + ".");
 			}
 			if(send.equals("gate")) {
-				diagram.addSendGateMessage(receive, msgText, messageArrowInfo.lineType, messageArrowInfo.arrowType, receiveLocalId);			}
+				diagram.addSendGateMessage(receive, msgText, messageArrowInfo.lineType, messageArrowInfo.arrowType, receiveLocalId);
+			}
 			else {
 				diagram.addReceiveGateMessage(send, msgText, messageArrowInfo.lineType, messageArrowInfo.arrowType, sendLocalId);
-			}		}
+			}
+		}
 		else if(send.equals("lost")) {
 			throw new SequenceDiagramException("Error: 'lost' can only be on the receiving end of a message.");
 		}
 		else if(send.equals("found")) {
 			if(duration != 0) {
-				throw new SequenceDiagramException("Error: 'lost' and 'found' messages can only have a duration of 0, but the duration was " + duration + ".");			}
+				throw new SequenceDiagramException("Error: 'lost' and 'found' messages can only have a duration of 0, but the duration was " + duration + ".");
+			}
 			diagram.addFoundMessage(receive, msgText, messageArrowInfo.lineType, messageArrowInfo.arrowType, receiveLocalId);
 		}
 		else
@@ -548,7 +557,8 @@ int MessageDuration() :
 		(
 			< MESSAGE_DURATION_INC > { duration = 1; }
 			(
-				duration = unsignedIntConstant() 				| (< MESSAGE_DURATION_INC >  { duration++; })*
+				duration = unsignedIntConstant() 
+				| (< MESSAGE_DURATION_INC >  { duration++; })*
 			)
 		)
 		| (
@@ -570,23 +580,28 @@ void GeneralOrdering(SequenceDiagramBuilder diagram):
 	String rightLifelineId = null;
 	String leftLifelineLocalId = null;
 	String rightLifelineLocalId = null;
-	boolean leftEarlier;}
+	boolean leftEarlier;
+}
 {
 	leftLifelineId = LifelineId()
 	< T_DOT >
 	leftLifelineLocalId = LifelineId()
-	(		< MESSAGE_ARROW_RIGHT_OPEN > { leftEarlier = true; }
+	(
+		< MESSAGE_ARROW_RIGHT_OPEN > { leftEarlier = true; }
 		| < MESSAGE_ARROW_LEFT_OPEN > { leftEarlier = false; }
 	)
 	rightLifelineId = LifelineId()
 	< T_DOT >
 	rightLifelineLocalId = LifelineId()
-	{		if(leftEarlier) {
-			diagram.addGeneralOrdering(leftLifelineId, leftLifelineLocalId, rightLifelineId, rightLifelineLocalId);		}
+	{
+		if(leftEarlier) {
+			diagram.addGeneralOrdering(leftLifelineId, leftLifelineLocalId, rightLifelineId, rightLifelineLocalId);
+		}
 		else {
 			diagram.addGeneralOrdering(rightLifelineId, rightLifelineLocalId, leftLifelineId, leftLifelineLocalId);
 		}
-	}}
+	}
+}
 
 void Coregion(SequenceDiagramBuilder diagram) :
 {
@@ -683,14 +698,18 @@ String TextUntilNewLine() :
 void InteractionUse(SequenceDiagramBuilder diagram):
 {
 	LifelineInterval interval;
-	String text = "";}
+	String text = "";
+}
 {
-	(		< REF >
+	(
+		< REF >
 		interval = LifelineInterval()
 		(text = TextUntilNewLine())?
-	)	{
+	)
+	{
 		diagram.addInteractionUse(interval.startId, interval.endId, text);
-	}}
+	}
+}
 
 void Continuation(SequenceDiagramBuilder diagram):
 {
@@ -713,11 +732,15 @@ void Continuation(SequenceDiagramBuilder diagram):
  */
 LifelineInterval LifelineInterval():
 {
-	LifelineInterval interval = new LifelineInterval();}
-{	interval.startId = LifelineId()
+	LifelineInterval interval = new LifelineInterval();
+}
+{
+	interval.startId = LifelineId()
 	(< LIST_DELIMITER >)?
 	interval.endId = LifelineId()
-	{		return interval;	}
+	{
+		return interval;
+	}
 }
 
 boolean booleanConstant() :

--- a/umlet-gwt/src/main/java/com/baselet/gwt/client/logging/GWTLogger.java
+++ b/umlet-gwt/src/main/java/com/baselet/gwt/client/logging/GWTLogger.java
@@ -1,7 +1,7 @@
 package com.baselet.gwt.client.logging;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 public class GWTLogger implements CustomLogger {
 

--- a/umlet-standalone/src/main/java/com/baselet/standalone/MainStandalone.java
+++ b/umlet-standalone/src/main/java/com/baselet/standalone/MainStandalone.java
@@ -15,8 +15,8 @@ import java.util.Timer;
 import javax.imageio.ImageIO;
 
 import org.apache.commons.io.filefilter.WildcardFileFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.Main;
 import com.baselet.control.config.Config;

--- a/umlet-standalone/src/main/java/com/baselet/standalone/gui/StandaloneGUI.java
+++ b/umlet-standalone/src/main/java/com/baselet/standalone/gui/StandaloneGUI.java
@@ -14,8 +14,8 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.CanCloseProgram;
 import com.baselet.control.Main;

--- a/umlet-swing/src/main/java/com/baselet/control/Main.java
+++ b/umlet-swing/src/main/java/com/baselet/control/Main.java
@@ -11,8 +11,8 @@ import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 import javax.swing.filechooser.FileSystemView;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.config.Config;
 import com.baselet.control.config.handler.ConfigHandler;

--- a/umlet-swing/src/main/java/com/baselet/control/config/Config.java
+++ b/umlet-swing/src/main/java/com/baselet/control/config/Config.java
@@ -6,8 +6,8 @@ import java.io.File;
 
 import javax.swing.UIManager;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.basics.geom.Dimension;
 import com.baselet.control.constants.SystemInfo;

--- a/umlet-swing/src/main/java/com/baselet/control/util/Path.java
+++ b/umlet-swing/src/main/java/com/baselet/control/util/Path.java
@@ -5,8 +5,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.constants.SystemInfo;
 import com.baselet.control.enums.Os;

--- a/umlet-swing/src/main/java/com/baselet/diagram/DiagramHandler.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/DiagramHandler.java
@@ -11,8 +11,8 @@ import java.util.Vector;
 
 import javax.swing.JOptionPane;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.ErrorMessages;
 import com.baselet.control.HandlerElementMap;

--- a/umlet-swing/src/main/java/com/baselet/diagram/DrawPanel.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/DrawPanel.java
@@ -23,8 +23,8 @@ import javax.swing.JScrollPane;
 import javax.swing.RepaintManager;
 import javax.swing.ScrollPaneConstants;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.basics.geom.Rectangle;
 import com.baselet.control.config.Config;

--- a/umlet-swing/src/main/java/com/baselet/diagram/SelectorFrame.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/SelectorFrame.java
@@ -6,8 +6,8 @@ import java.awt.Graphics2D;
 
 import javax.swing.JComponent;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.enums.LineType;
 import com.baselet.control.util.Utils;

--- a/umlet-swing/src/main/java/com/baselet/diagram/StartUpHelpText.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/StartUpHelpText.java
@@ -21,8 +21,8 @@ import java.util.Scanner;
 
 import javax.swing.JEditorPane;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.constants.SystemInfo;
 import com.baselet.control.enums.Metakey;

--- a/umlet-swing/src/main/java/com/baselet/diagram/io/DiagramFileHandler.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/io/DiagramFileHandler.java
@@ -29,8 +29,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 

--- a/umlet-swing/src/main/java/com/baselet/diagram/io/InputHandler.java
+++ b/umlet-swing/src/main/java/com/baselet/diagram/io/InputHandler.java
@@ -3,8 +3,8 @@ package com.baselet.diagram.io;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.DefaultHandler;
 

--- a/umlet-swing/src/main/java/com/baselet/element/old/OldGridElement.java
+++ b/umlet-swing/src/main/java/com/baselet/element/old/OldGridElement.java
@@ -17,8 +17,8 @@ import java.util.Vector;
 
 import javax.swing.JComponent;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.HandlerElementMap;
 import com.baselet.control.Main;

--- a/umlet-swing/src/main/java/com/baselet/element/old/custom/CustomElementCompiler.java
+++ b/umlet-swing/src/main/java/com/baselet/element/old/custom/CustomElementCompiler.java
@@ -14,8 +14,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.jdt.core.compiler.batch.BatchCompiler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.config.Config;
 import com.baselet.control.config.SharedConfig;

--- a/umlet-swing/src/main/java/com/baselet/generator/java/bcel/BcelJavaClass.java
+++ b/umlet-swing/src/main/java/com/baselet/generator/java/bcel/BcelJavaClass.java
@@ -6,8 +6,8 @@ import org.apache.bcel.classfile.ClassParser;
 import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 public class BcelJavaClass implements com.baselet.generator.java.JavaClass {
 

--- a/umlet-swing/src/main/java/com/baselet/generator/java/jp/JpJavaClass.java
+++ b/umlet-swing/src/main/java/com/baselet/generator/java/jp/JpJavaClass.java
@@ -5,8 +5,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.generator.java.Field;
 import com.baselet.generator.java.JavaClass;

--- a/umlet-swing/src/main/java/com/baselet/gui/BaseGUI.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/BaseGUI.java
@@ -12,8 +12,8 @@ import javax.swing.JPopupMenu;
 import javax.swing.UIManager;
 import javax.swing.plaf.InsetsUIResource;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.CanCloseProgram;
 import com.baselet.control.HandlerElementMap;

--- a/umlet-swing/src/main/java/com/baselet/gui/BrowserLauncher.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/BrowserLauncher.java
@@ -12,8 +12,8 @@ import java.util.Map;
 import java.util.Scanner;
 import java.util.function.BiFunction;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.constants.SystemInfo;
 import com.baselet.control.enums.Os;

--- a/umlet-swing/src/main/java/com/baselet/gui/MailPanel.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/MailPanel.java
@@ -36,8 +36,8 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.UIManager;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.config.Config;
 import com.baselet.control.config.ConfigMail;

--- a/umlet-swing/src/main/java/com/baselet/gui/OptionPanel.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/OptionPanel.java
@@ -18,8 +18,8 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.UIManager.LookAndFeelInfo;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.Main;
 import com.baselet.control.config.Config;

--- a/umlet-swing/src/main/java/com/baselet/gui/command/AddElement.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/command/AddElement.java
@@ -2,8 +2,8 @@ package com.baselet.gui.command;
 
 import java.awt.Point;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.HandlerElementMap;
 import com.baselet.control.constants.Constants;

--- a/umlet-swing/src/main/java/com/baselet/gui/command/Move.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/command/Move.java
@@ -2,8 +2,8 @@ package com.baselet.gui.command;
 
 import java.util.Collection;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.HandlerElementMap;
 import com.baselet.control.basics.geom.Point;

--- a/umlet-swing/src/main/java/com/baselet/gui/filedrop/FileDropListener.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/filedrop/FileDropListener.java
@@ -5,8 +5,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.Main;
 import com.baselet.diagram.Notifier;

--- a/umlet-swing/src/main/java/com/baselet/gui/listener/DiagramListener.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/listener/DiagramListener.java
@@ -7,8 +7,8 @@ import java.awt.event.MouseWheelListener;
 
 import javax.swing.JComponent;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.Main;
 import com.baselet.control.basics.Converter;

--- a/umlet-swing/src/main/java/com/baselet/gui/listener/GridElementListener.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/listener/GridElementListener.java
@@ -11,8 +11,8 @@ import java.util.Vector;
 import javax.swing.JComponent;
 import javax.swing.JPopupMenu;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.Main;
 import com.baselet.control.basics.Converter;

--- a/umlet-swing/src/main/java/com/baselet/gui/menu/AboutDialog.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/menu/AboutDialog.java
@@ -9,8 +9,8 @@ import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import javax.swing.border.LineBorder;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.baselet.util.logging.Logger;
+import com.baselet.util.logging.LoggerFactory;
 
 import com.baselet.control.enums.Program;
 import com.baselet.gui.listener.HyperLinkActiveListener;


### PR DESCRIPTION
As an effort to generalize our logging, this PR will introduce a custom Logger interface, which will be used among all UMLet components. Currently, there is a single `java.utils.logging` implementation, which is returned by the factory. If in the future it is decided that the capabilities of `java.utils.logging` are not enough, a new implementation can be created, using a different logging backend, making the switch easier than editing all the existing files.