### PR TITLE
Links now also work for elements in groups.

### DIFF
--- a/umlet-swing/src/main/java/com/baselet/gui/BaseGUI.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/BaseGUI.java
@@ -14,11 +14,13 @@ import javax.swing.plaf.InsetsUIResource;
 
 import com.baselet.control.CanCloseProgram;
 import com.baselet.control.HandlerElementMap;
+import com.baselet.control.Main;
 import com.baselet.control.config.Config;
 import com.baselet.diagram.CustomPreviewHandler;
 import com.baselet.diagram.DiagramHandler;
 import com.baselet.diagram.DrawPanel;
 import com.baselet.element.facet.common.GroupFacet;
+import com.baselet.element.facet.common.LinkFacet;
 import com.baselet.element.interfaces.GridElement;
 import com.baselet.element.old.custom.CustomElement;
 import com.baselet.element.old.custom.CustomElementHandler;
@@ -59,7 +61,8 @@ public abstract class BaseGUI {
 		MenuFactorySwing menuFactory = MenuFactorySwing.getInstance();
 
 		JPopupMenu contextMenu = new JPopupMenu();
-		if (selected_elements.size() == 1 && selected_elements.iterator().next().getSetting("link") != null) {
+		GridElement editedGridElement = Main.getInstance().getEditedGridElement();
+		if ((editedGridElement != null) && (editedGridElement.getSetting(LinkFacet.LINK) != null)) {
 			contextMenu.add(menuFactory.createOpenLinkMenu());
 		}
 		if (e instanceof CustomElement) {

--- a/umlet-swing/src/main/java/com/baselet/gui/menu/MenuFactory.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/menu/MenuFactory.java
@@ -246,20 +246,17 @@ public class MenuFactory {
 					actualHandler.getController().executeCommand(new ChangeElementSetting(LayerFacet.KEY, valueMap));
 				}
 				else if (menuItem.equals(OPEN_LINK) && actualHandler != null && actualSelector != null) {
-					List<GridElement> elements = actualSelector.getSelectedElements();
-					if (elements.size() == 1) {
-						String absoluteLink = elements.get(0).getSetting(LinkFacet.LINK);
-						File link = new File(absoluteLink);
-						if (!link.isAbsolute()) {
-							String parentDir = new File(actualHandler.getFileHandler().getFullPathName()).getParent(); // relative paths are relative to the currently opened diagram
-							try {
-								absoluteLink = new File(parentDir + "/" + absoluteLink).getCanonicalFile().getAbsolutePath();
-							} catch (Exception ex) {
-								throw new RuntimeException("Cannot get link path", ex);
-							}
+					String absoluteLink = main.getEditedGridElement().getSetting(LinkFacet.LINK);
+					File link = new File(absoluteLink);
+					if (!link.isAbsolute()) {
+						String parentDir = new File(actualHandler.getFileHandler().getFullPathName()).getParent(); // relative paths are relative to the currently opened diagram
+						try {
+							absoluteLink = new File(parentDir + "/" + absoluteLink).getCanonicalFile().getAbsolutePath();
+						} catch (Exception ex) {
+							throw new RuntimeException("Cannot get link path", ex);
 						}
-						main.doOpen(absoluteLink);
 					}
+					main.doOpen(absoluteLink);
 				}
 			}
 		});


### PR DESCRIPTION
Links now also work for elements which are part of a group.

The procedure to open a link within an element of a group is
(a) Left click (i.e. select) the element (and with it also the group). The properties of the selected element including the link statement are then visible in the properties panel.
(b) Right click to open the context menu and select the "Open Link" item.

I adapted the testfiles to test the new feature: [link_feature_testfiles.zip](https://github.com/umlet/umlet/files/13550759/link_feature_testfiles.zip)

I could imagine that you are not happy with my changes in BaseGUI.java. Feel free to refactor the code to fit your coding style.

It's a pleasure and honor to contribute.
