### PR TITLE
Added option to enable line wrap + line numbers in properties editor (see issues 429 and 214)

### DIFF
--- a/umlet-swing/src/main/java/com/baselet/control/config/Config.java
+++ b/umlet-swing/src/main/java/com/baselet/control/config/Config.java
@@ -52,6 +52,7 @@ public class Config {
 	private String defaultFontFamily = Font.SANS_SERIF;
 	private Integer defaultFontsize = 14;
 	private Integer propertiesPanelFontsize = 11;
+        private boolean propertiesPanelLineWrap = false;
 	private Integer exportScale = 1;
 	private Integer exportDpi = null;
 
@@ -277,6 +278,14 @@ public class Config {
 
 	public void setPropertiesPanelFontsize(Integer propertiesPanelFontsize) {
 		this.propertiesPanelFontsize = propertiesPanelFontsize;
+	}
+
+	public boolean getPropertiesPanelLineWrap() {
+		return propertiesPanelLineWrap;
+	}
+
+	public void setPropertiesPanelLineWrap(boolean propertiesPanelLineWrap) {
+		this.propertiesPanelLineWrap = propertiesPanelLineWrap;
 	}
 
 	public Integer getExportScale() {

--- a/umlet-swing/src/main/java/com/baselet/control/config/handler/ConfigHandler.java
+++ b/umlet-swing/src/main/java/com/baselet/control/config/handler/ConfigHandler.java
@@ -36,6 +36,7 @@ public class ConfigHandler {
 	private static final String SHOW_STICKINGPOLYGON = "show_stickingpolygon";
 	private static final String SHOW_GRID = "show_grid";
 	private static final String ENABLE_CUSTOM_ELEMENTS = "enable_custom_elements";
+	private static final String PROPERTIES_PANEL_LINE_WRAP = "properties_panel_line_wrap";
 	private static final String UI_MANAGER = "ui_manager";
 	private static final String PRINT_PADDING = "print_padding";
 	private static final String PDF_EXPORT_FONT = "pdf_export_font";
@@ -94,6 +95,7 @@ public class ConfigHandler {
 		SharedConfig.getInstance().setShow_stickingpolygon(getBoolProperty(props, SHOW_STICKINGPOLYGON, SharedConfig.getInstance().isShow_stickingpolygon()));
 		cfg.setShow_grid(getBoolProperty(props, SHOW_GRID, cfg.isShow_grid()));
 		cfg.setEnable_custom_elements(getBoolProperty(props, ENABLE_CUSTOM_ELEMENTS, cfg.isEnable_custom_elements()));
+		cfg.setPropertiesPanelLineWrap(getBoolProperty(props, PROPERTIES_PANEL_LINE_WRAP, cfg.getPropertiesPanelLineWrap()));
 		cfg.setUiManager(getStringProperty(props, UI_MANAGER, cfg.getUiManager()));
 		cfg.setPrintPadding(getIntProperty(props, PRINT_PADDING, cfg.getPrintPadding()));
 		cfg.setPdfExportFont(getStringProperty(props, PDF_EXPORT_FONT, cfg.getPdfExportFont()));
@@ -173,6 +175,7 @@ public class ConfigHandler {
 			props.setProperty(SHOW_STICKINGPOLYGON, Boolean.toString(SharedConfig.getInstance().isShow_stickingpolygon()));
 			props.setProperty(SHOW_GRID, Boolean.toString(cfg.isShow_grid()));
 			props.setProperty(ENABLE_CUSTOM_ELEMENTS, Boolean.toString(cfg.isEnable_custom_elements()));
+			props.setProperty(PROPERTIES_PANEL_LINE_WRAP, Boolean.toString(cfg.getPropertiesPanelLineWrap()));
 			props.setProperty(UI_MANAGER, cfg.getUiManager());
 			props.setProperty(PRINT_PADDING, Integer.toString(cfg.getPrintPadding()));
 			props.setProperty(PDF_EXPORT_FONT, cfg.getPdfExportFont());

--- a/umlet-swing/src/main/java/com/baselet/gui/OptionPanel.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/OptionPanel.java
@@ -48,6 +48,7 @@ public class OptionPanel extends JPanel implements ActionListener {
 	private final JCheckBox enable_custom_elements = new JCheckBox();
 	private final JCheckBox checkForUpdates = new JCheckBox();
 	private final JCheckBox developerMode = new JCheckBox();
+	private final JCheckBox propertiesPanelLineWrap = new JCheckBox();
 	private final JTextField pdfFont = new HintTextField("Path to font e.g.; c:/windows/fonts/msgothic.ttc,1");
 	private final JTextField pdfFontBold = new HintTextField("same as above but used for bold text");
 	private final JTextField pdfFontItalic = new HintTextField("same as above but used for italic text");
@@ -76,6 +77,8 @@ public class OptionPanel extends JPanel implements ActionListener {
 		this.add(show_stickingpolygon);
 		this.add(new JLabel("Show grid"));
 		this.add(show_grid);
+		this.add(new JLabel("Properties panel line wrapping (requires restart)"));
+		this.add(propertiesPanelLineWrap);
 		this.add(new JLabel("Enable Custom Elements"));
 		this.add(enable_custom_elements);
 		this.add(new JLabel("Check for " + Program.getInstance().getProgramName() + " updates"));
@@ -136,6 +139,7 @@ public class OptionPanel extends JPanel implements ActionListener {
 		show_stickingpolygon.setSelected(SharedConfig.getInstance().isShow_stickingpolygon());
 		show_grid.setSelected(Config.getInstance().isShow_grid());
 		enable_custom_elements.setSelected(Config.getInstance().isEnable_custom_elements());
+		propertiesPanelLineWrap.setSelected(Config.getInstance().getPropertiesPanelLineWrap());
 		checkForUpdates.setSelected(Config.getInstance().isCheckForUpdates());
 		developerMode.setSelected(SharedConfig.getInstance().isDev_mode());
 		ui_manager.setSelectedIndex(uis_technicalNames.indexOf(Config.getInstance().getUiManager()));
@@ -170,6 +174,7 @@ public class OptionPanel extends JPanel implements ActionListener {
 			SharedConfig.getInstance().setShow_stickingpolygon(show_stickingpolygon.isSelected());
 			Config.getInstance().setShow_grid(show_grid.isSelected());
 			Config.getInstance().setEnable_custom_elements(enable_custom_elements.isSelected());
+			Config.getInstance().setPropertiesPanelLineWrap(propertiesPanelLineWrap.isSelected());
 			Config.getInstance().setCheckForUpdates(checkForUpdates.isSelected());
 			SharedConfig.getInstance().setDev_mode(developerMode.isSelected());
 			Config.getInstance().setDefaultFontsize((Integer) default_fontsize.getSelectedItem());

--- a/umlet-swing/src/main/java/com/baselet/gui/pane/OwnSyntaxPane.java
+++ b/umlet-swing/src/main/java/com/baselet/gui/pane/OwnSyntaxPane.java
@@ -22,6 +22,7 @@ import org.fife.ui.rsyntaxtextarea.TokenMap;
 import org.fife.ui.rsyntaxtextarea.TokenTypes;
 import org.fife.ui.rtextarea.RTextScrollPane;
 
+import com.baselet.control.config.Config;
 import com.baselet.control.basics.Converter;
 import com.baselet.control.config.DerivedConfig;
 import com.baselet.diagram.CurrentDiagram;
@@ -84,9 +85,10 @@ public class OwnSyntaxPane {
 		propertyLabel.setFont(DerivedConfig.getPanelHeaderFont());
 		panel.add(propertyLabel);
 
+                textArea.setLineWrap(Config.getInstance().getPropertiesPanelLineWrap());
 		textArea.setAntiAliasingEnabled(true);
 		textArea.setFont(DerivedConfig.getPanelContentFont());
-		scrollPane = new RTextScrollPane(textArea, false);
+		scrollPane = new RTextScrollPane(textArea, Config.getInstance().getPropertiesPanelLineWrap());
 		scrollPane.setAlignmentX(Component.LEFT_ALIGNMENT);
 		scrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
 		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);


### PR DESCRIPTION
I added a new option in the options GUI named "Properties panel line wrapping (requires restart)" which is per default false.
As long as the option is false nothing changes for the user.

If the user sets the option to true, saves the options and then restarts UMLet, line wrap and line numbering in the properties editor are enabled.

There are two minor drops of bitterness in this implementation:
1. The line wrap doesn't consider word boundaries.
2. When the cursor is positioned in a wrapped line, only the section of the line is marked, that contains the cursor.

In my opinion it nevertheless is useful when correcting/reworking elements with a lot of text. 