### PR TITLE
Fix notation for Extend and Include relationships in use case diagrams

### DIFF
--- a/umlet-res/src/main/resources/palettes/UML Use Case.uxf
+++ b/umlet-res/src/main/resources/palettes/UML Use Case.uxf
@@ -140,7 +140,7 @@ valign=center</panel_attributes>
       <h>32</h>
     </coordinates>
     <panel_attributes>lt=.&gt;
-&lt;&lt;extends&gt;&gt;</panel_attributes>
+&lt;&lt;extend&gt;&gt;</panel_attributes>
     <additional_attributes>10.0;20.0;120.0;20.0</additional_attributes>
   </element>
   <element>
@@ -152,7 +152,7 @@ valign=center</panel_attributes>
       <h>32</h>
     </coordinates>
     <panel_attributes>lt=.&gt;
-&lt;&lt;includes&gt;&gt;</panel_attributes>
+&lt;&lt;include&gt;&gt;</panel_attributes>
     <additional_attributes>10.0;20.0;120.0;20.0</additional_attributes>
   </element>
   <element>


### PR DESCRIPTION
The notation is "extend" and "include", without the final "s".

See, for instance, the bottom of page 642 of [the UML 2.5.1 spec](https://www.omg.org/spec/UML/2.5.1/PDF) or the examples at [uml-diagrams.org](https://www.uml-diagrams.org/use-case-diagrams.html).